### PR TITLE
Clone tables and reports; drop the stale table cache

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,32 @@
 History
 -------
 
+0.4.0 (unreleased)
+++++++++++++++++++
+
+* ``Table`` and ``Report`` can now be cloned from the admin, using a *Clone*
+  button on the change form. Cloning a table copies its columns and its sort
+  order; cloning a report copies its elements, which keep pointing at the same
+  tables and datasources. The clone's name gets a translatable ``(copy)``
+  suffix.
+
+  Both are also available programmatically as ``Table.clone()`` and
+  ``Report.clone()``. Neither modifies the source object.
+
+  Note: the button has not been verified against `grappelli`, which ships its
+  own ``admin/change_form.html``.
+
+* Fix stale table headers. A cached table class was kept per ``Table.pk`` for
+  the lifetime of the process and never invalidated, so editing a column's
+  label -- or deleting a column -- only became visible after restarting
+  Django. With several workers the page alternated between old and new
+  headers depending on which worker answered.
+
+  The cache is gone. Compiled column templates are cached instead, keyed by
+  the template source so no invalidation is needed, which more than pays the
+  removal back: rendering a 500-row table is ~1.25x faster than before, since
+  ``TemplateColumn`` used to recompile its template for every single cell.
+
 0.3.2 (2026-06-03)
 ++++++++++++++++++
 

--- a/docs/superpowers/specs/2026-07-22-cloning-and-cache-design.md
+++ b/docs/superpowers/specs/2026-07-22-cloning-and-cache-design.md
@@ -1,7 +1,7 @@
 # Klonowanie tabel i raportów + usunięcie cache'u tabel
 
 Data: 2026-07-22
-Status: zaakceptowana
+Status: zaakceptowana, po review
 
 ## Cel
 
@@ -11,6 +11,8 @@ Trzy niezależne zmiany w `django-flexible-reports`:
 2. Możliwość sklonowania `Report` (wraz z jego elementami).
 3. Naprawa błędu: zmiana `label` w bazie nie jest widoczna bez restartu procesu
    Django.
+
+Wersje zweryfikowane w `.venv`: Django 6.0.7, django-tables2 3.0.0.
 
 ## Kontekst — diagnoza błędu z punktu 3
 
@@ -46,7 +48,7 @@ Konsekwencje:
 ### Pomiar: ile ten cache jest wart
 
 Benchmark na tabeli 8 kolumn typu `TemplateColumn` z szablonem `{{ value }}`
-(sqlite in-memory, Python 3.13, django-tables2 z `.venv`):
+(sqlite in-memory, Python 3.13, django-tables2 3.0.0):
 
 | | 20 wierszy | 100 | 500 | 1000 |
 |---|---|---|---|---|
@@ -62,7 +64,7 @@ Powód jest strukturalny, potwierdzony w źródłach `django_tables2`:
 
 - `Table.__init__` (`tables.py:318`) wykonuje `copy.deepcopy(type(self).base_columns)`
   przy **każdej** instancjacji. Zapamiętanie klasy nie omija tego deepcopy.
-- `TemplateColumn.render()` (`columns/templatecolumn.py`) wykonuje
+- `TemplateColumn.render()` (`columns/templatecolumn.py:116`) wykonuje
   `Template(self.template_code)` przy **każdej komórce**. Dla tabeli 500×8 to
   4000 kompilacji szablonu na jeden render; cache klasy nie eliminuje z tego nic.
 
@@ -95,6 +97,44 @@ Odrzucone alternatywy:
   wymaga nowego pola, migracji i sygnałów z `Column`/`ColumnOrder`, żeby
   uratować 0,46 ms. Nadinżynieria wobec zmierzonych liczb.
 
+Usunięcie cache'u jest bezpieczne: jedynym konsumentem jest
+`templatetags/flexible_reports_tags.py:12` -> `as_html` -> `table()`
+(`adapters/django_tables2.py:148-149`), który natychmiast instancjuje klasę i
+nigdzie jej nie przechowuje. Nic nie zależy od tożsamości (identity) zwracanej
+klasy. Prefiks sortowania pochodzi ze stanu w bazie
+(`SortIndividually.get_prefix` -> `table.pk`), więc przebudowana klasa zachowuje
+się identycznie przy sortowaniu i paginacji z querystringa.
+
+## Nazewnictwo klonów (wspólne dla A i B)
+
+Sufiks musi być **tłumaczalny**. Cały pakiet używa angielskich `msgid` pod
+`gettext_lazy` i ma polskie tłumaczenie w
+`flexible_reports/locale/pl/LC_MESSAGES/django.po` (71 msgidów). Pakiet jest
+publikowany na PyPI z angielskimi klasyfikatorami i README, więc zaszycie
+polskiego „kopia" w danych byłoby błędem dla każdego nieanglojęzycznego
+wdrożenia.
+
+- msgid: `"copy"`, tłumaczenie pl: `"kopia"`.
+- Etykieta: `"X (copy)"`, kolejne `"X (copy 2)"`, `"X (copy 3)"`.
+- **Klon klonu**: z etykiety źródłowej najpierw **zdejmujemy** istniejący sufiks
+  (regex zbudowany z aktualnego tłumaczenia), więc klon `"X (copy)"` daje
+  `"X (copy 2)"`, a nie `"X (copy) (copy)"`. Gdy etykieta powstała przy innym
+  aktywnym języku, regex nie dopasuje się i dostaniemy zagnieżdżony sufiks —
+  degradacja jest kosmetyczna i akceptowana.
+- Numer wybieramy jako pierwszy wolny, sprawdzając istniejące wartości w bazie.
+  Skan jest **wyścigowy**: dwa równoczesne klonowania mogą wyliczyć tę samą
+  nazwę. Żadne pole nie ma `unique=True`, więc nie ma wyjątku — powstaną dwie
+  identyczne etykiety. Akceptujemy to świadomie; klonowanie to operacja
+  administracyjna wykonywana ręcznie.
+
+Slug (`Report.slug`, `SlugField()` czyli `max_length=50`, `models/report.py:105`):
+
+- sufiks `-copy`, `-copy-2`, ... (slugifikowany, żeby zniósł tłumaczenia z
+  diakrytykami);
+- **skracamy rdzeń**, nie całość: rdzeń jest przycinany tak, by
+  `len(rdzeń + sufiks) <= max_length`. Dzięki temu sufiks nigdy nie zostaje
+  obcięty, a slug pozostaje rozróżnialny.
+
 ## Zakres zmian
 
 ### A. `Table.clone()`
@@ -104,23 +144,48 @@ metoda `clone()` na modelu. Logika mieszka w modelu, admin ją tylko wywołuje �
 dzięki temu klonowanie działa też ze skryptu i z shella oraz testuje się bez
 warstwy HTTP.
 
+**Zasada nadrzędna: `clone()` nie modyfikuje `self` ani żadnego obiektu
+osiągalnego z `self`.** Wywołanie `table.clone()` musi zostawić `table` i jego
+kolumny nietknięte — po powrocie `table.pk` jest niezmieniony i dalsze
+`table.save()` zapisuje oryginał. Ma to znaczenie praktyczne: gdy obiekt przyszedł
+z `prefetch_related("column_set")`, menedżer relacji zwraca **zacache'owane**
+instancje, więc wyzerowanie im PK zepsułoby obiekty trzymane przez wywołującego
+(`TableAdmin.columns`, `admin/table.py:94-95`, iteruje właśnie `obj.column_set.all()`).
+
 Algorytm (cały w `transaction.atomic`):
 
-1. Wczytaj do pamięci `column_set` i `columnorder_set` **przed** zmianą PK.
-2. Skopiuj `Table` (`pk = None`, `_state.adding = True`), ustaw nową etykietę.
-3. Skopiuj kolumny, budując mapę `stare_pk -> nowy obiekt Column`.
-4. Skopiuj `ColumnOrder`, przepinając pole `column` przez tę mapę.
+1. Pobierz dzieci **świeżym querysetem** (`Column.objects.filter(parent=self)`,
+   `ColumnOrder.objects.filter(table=self)`), nie przez menedżer relacji na
+   `self` — omija to cache prefetch.
+2. Skopiuj `Table`: świeży obiekt (refetch albo `copy.copy`), `pk = None`,
+   ustaw nową etykietę, `save()`. Nigdy nie zerować `self.pk`.
+3. Dla każdej kolumny: zapamiętaj `old_pk` **przed** wyzerowaniem, ustaw
+   `pk = None`, **`parent = klon`**, `save()`; zbuduj mapę
+   `old_pk -> nowy obiekt Column`.
+4. Dla każdego `ColumnOrder`: `pk = None`, **`table = klon`** oraz
+   **`column = mapa[old.column_id]`**, `save()`.
 5. Zwróć nowy obiekt.
 
-Krok 4 jest krytyczny: `ColumnOrder` ma FK zarówno do `Table`, jak i do
-`Column`. Bez przepięcia klon sortowałby się po kolumnach oryginału, co jest
-cichym błędem — tabela renderuje się poprawnie, tylko w złej kolejności, i
-psuje się dopiero przy edycji kolumn oryginału.
+Oba przepięcia w kroku 4 są krytyczne i muszą być wykonane jawnie. `ColumnOrder`
+ma FK do `Table` **i** do `Column` (`models/table.py:74-81`):
 
-Nazwa klonu: `label` -> `"X (kopia)"`, przy kolejnych klonach `"X (kopia 2)"`,
-`"X (kopia 3)"`. `Table.label` nie ma ograniczenia unikalności, więc numerowanie
-jest wyłącznie kosmetyczne — ale bez niego lista wyboru tabeli w
-`ReportElement` wypełnia się nierozróżnialnymi pozycjami.
+- bez przepięcia `column` klon sortowałby się po kolumnach oryginału;
+- bez przepięcia `table` wpisy zostałyby przy oryginale, a `columnorder_set`
+  klonu byłby pusty i klon po cichu straciłby sortowanie.
+
+Oba to ciche błędy — tabela renderuje się poprawnie, tylko w złej kolejności.
+
+`clone()` na niezapisanej instancji (`pk is None`) nie jest wspierane; dostęp do
+menedżera relacji podniesie `ValueError`. Nie dodajemy własnej walidacji.
+
+Relacje wskazujące na `Table`, świadomie **nieklonowane**: `ReportElement.table`
+(`models/report.py:51`) — klonowanie tabeli nie rusza raportów, które jej
+używają. Poza `Column.parent` i `ColumnOrder.table` nic innego w pakiecie ani w
+`test_app` nie wskazuje na `Table`. Nie ma żadnych M2M.
+
+`Column.Meta.unique_together = ("parent", "id", "position")` (`column.py:114`)
+zawiera PK, więc więz jest w praktyce pusty — klon nie może go naruszyć nawet
+przy powtórzonych `position`.
 
 ### B. `Report.clone()`
 
@@ -129,11 +194,12 @@ Klonowanie **płytkie**: nowy `Report` i nowe `ReportElement`-y wskazujące na
 mnożyłoby w adminie w większości identyczne tabele. Kto chce niezależnej
 tabeli, klonuje ją osobno (punkt A) i przepina element.
 
-- `title` -> `"X (kopia)"`, analogicznie do `Table.label`.
+Ta sama zasada nienaruszalności źródła co w A.
+
+- `title` -> `"X (copy)"`, wg reguł z sekcji „Nazewnictwo klonów".
 - `template` kopiowany dosłownie.
-- `slug` -> unikalny w obrębie `Report` (`x-kopia`, `x-kopia-2`), z pilnowaniem
-  `max_length` pola `SlugField`.
-- Slugi `ReportElement` pozostają **bez zmian**.
+- `slug` -> unikalny, wg reguł skracania z sekcji „Nazewnictwo klonów".
+- Elementy: `pk = None`, **`parent = klon`**, slug **bez zmian**.
 
 Uzasadnienie unikalności sluga raportu: `Report.slug` nie ma `unique=True` i nie
 jest używany w URL-ach tego pakietu (`urls.py` jest pusty), ale projekty
@@ -145,35 +211,102 @@ Uzasadnienie niezmienności slugów elementów: `unique_together` to
 adresuje elementy przez `{{ elements.jakis_slug }}`. Zmiana slugów rozspójniłaby
 skopiowany szablon z elementami.
 
+Elementy typu except-catchall (`datasource=None`, ustawione `base_model`)
+kopiują się bez zmian — to zwykłe nullowalne FK.
+
+Jedyną relacją wskazującą na `Report` jest `ReportElement.parent`
+(`models/report.py:19`).
+
 ### C. Admin — przycisk w formularzu edycji
 
 Wspólny `CloneAdminMixin` w `flexible_reports/admin/cloning.py`, podpięty pod
 `TableAdmin` i `ReportAdmin`.
 
-- `get_urls()` dokłada trasę `<path:object_id>/clone/` o nazwie
-  `flexible_reports_<model>_clone`.
-- Widok przyjmuje **wyłącznie POST** (`require_POST`). Klonowanie zmienia stan
-  bazy, więc zwykły link `<a href>` pozwoliłby stworzyć obiekt przez
-  `<img src="...">` osadzony w obcej stronie. Formularz daje CSRF za darmo.
-- Uprawnienia: wymagane `has_add_permission` (tworzymy obiekt) **oraz**
-  `has_view_permission` na obiekcie źródłowym. Brak któregokolwiek -> 403.
-- Nieistniejące `object_id` -> 404.
-- Po sklonowaniu: `log_addition()` (wpis w historii admina),
-  `message_user(..., messages.SUCCESS)` i przekierowanie na formularz edycji
-  **klonu**, nie oryginału.
+**Rejestracja trasy — kolejność jest krytyczna:**
 
-Szablon `flexible_reports/templates/admin/flexible_reports/change_form_with_clone.html`
+```python
+def get_urls(self):
+    return my_urls + super().get_urls()   # NIE odwrotnie
+```
+
+`ModelAdmin.get_urls()` kończy się wstecznie kompatybilnym catch-allem
+`path("<path:object_id>/", RedirectView...)` (`django/contrib/admin/options.py:735`).
+Konwerter `path:` łapie ukośniki, więc URL `5/clone/` dopasowałby się do niego
+jako `object_id="5/clone"` i przekierował na `.../5/clone/change/` -> 404.
+Doklejenie własnych tras **za** `super()` daje martwą trasę.
+
+**Metoda HTTP i opakowanie widoku:**
+
+```python
+path(
+    "<path:object_id>/clone/",
+    self.admin_site.admin_view(require_POST(self.clone_view)),
+    name="%s_%s_clone" % info,
+)
+```
+
+Kolejność opakowań jest istotna:
+
+- `require_POST` **nie może** być dekoratorem w ciele klasy. Jego wrapper ma
+  sygnaturę `inner(request, *args, **kwargs)`
+  (`django/views/decorators/http.py:36`), więc przy dekoracji niezwiązanej
+  metody `request` zbindowałby się do `self` i dostalibyśmy
+  `AttributeError: 'TableAdmin' object has no attribute 'method'` — czyli 500
+  zamiast obiecanego 405. Dekorujemy **związaną** metodę wewnątrz `get_urls()`
+  (równoważnie: `@method_decorator(require_POST)` na metodzie).
+- `admin_view` musi być **na zewnątrz**, żeby anonimowy GET dostał
+  przekierowanie na login, a nie 405 (drobny wyciek informacji o istnieniu URL-a).
+  `admin_view` dokłada też sprawdzenie `is_staff`, `never_cache` i obsługę
+  sesji — bez niego widok byłby chroniony wyłącznie przypadkiem, przez
+  `has_add_permission`.
+
+**Uprawnienia:** wymagane `has_add_permission(request)` (tworzymy obiekt) oraz
+`has_view_permission(request, obj)` na obiekcie źródłowym. Brak któregokolwiek
+-> `PermissionDenied` (403). Nie wymagamy uprawnienia `change` na źródle — to
+odpowiada filozofii wbudowanego „save as new" w Django.
+
+**Nieistniejące `object_id`** -> 404 (`self.get_object()` zwraca `None`).
+
+**Po sklonowaniu:**
+
+- `self.log_addition(request, new_obj, [{"added": {}}])` — argument `message` jest
+  **wymagany** (`options.py:936`), a ta struktura sprawia, że strona historii
+  renderuje poprawne „Added." zamiast surowego stringa.
+- `message_user(..., messages.SUCCESS)`.
+- Przekierowanie na formularz edycji **klonu**. Jeśli użytkownik nie ma
+  uprawnienia `change` do modelu, przekierowujemy na changelistę — inaczej po
+  udanej akcji zobaczyłby 403. To odwzorowanie zachowania
+  `ModelAdmin._response_post_save`.
+
+Przekierowanie budujemy przez `reverse()` z PK nowego obiektu — brak komponentu
+sterowanego przez użytkownika, więc nie ma ryzyka open redirect.
+
+**Szablon** `flexible_reports/templates/admin/flexible_reports/change_form_with_clone.html`
 rozszerza `admin/change_form.html` i nadpisuje `{% block object-tools-items %}`,
-dokładając `{{ block.super }}` oraz `<li>` z małym formularzem POST.
+dokładając `{{ block.super }}` oraz `<li>` z małym formularzem POST z
+`{% csrf_token %}`.
 
-Weryfikacja: w `admin/change_form.html` (Django z `.venv`) blok
-`object-tools-items` jest w linii 31, a główny `<form>` otwiera się dopiero w
-linii 36 — nasz formularz nie zagnieżdża się więc w cudzym, co byłoby
-niepoprawnym HTML-em.
+Weryfikacja w Django 6.0.7: blok `object-tools-items` jest w linii 31, a główny
+`<form>` otwiera się w linii **37** — nasz formularz nie zagnieżdża się więc w
+cudzym, co byłoby niepoprawnym HTML-em. Blok renderuje się tylko pod
+`{% if change and not is_popup %}` (linia 29), co samo z siebie trzyma przycisk
+z dala od formularza dodawania.
+
+Widok przyjmuje wyłącznie POST, bo klonowanie zmienia stan bazy: zwykły link
+`<a href>` pozwoliłby stworzyć obiekt przez `<img src="...">` osadzony w obcej
+stronie. Formularz daje CSRF za darmo.
 
 Admin ustawia `change_form_template` na powyższy szablon. `TableAdmin` i
-`ReportAdmin` nie definiują dziś własnego `change_form_template`, więc nic nie
-nadpisujemy.
+`ReportAdmin` nie definiują dziś własnego `change_form_template`
+(`admin/table.py:88-114`, `admin/report.py:53-65`), więc nic nie nadpisujemy.
+Nowy szablon łapie się w `package-data` (`templates/**/*` w `pyproject.toml`).
+
+**Znane ograniczenie — grappelli.** Pakiet opcjonalnie wspiera grappelli
+(`admin/helpers.py:8-14`). Z zainstalowanym grappelli
+`{% extends "admin/change_form.html" %}` rozwiąże się do szablonu *grappelli*,
+którego struktura bloków jest inna. Nie dało się tego zweryfikować (grappelli nie
+ma w `.venv`). Ryzyko: przycisk może się nie pokazać. Do sprawdzenia ręcznie
+przed wydaniem; odnotowane w `HISTORY.rst`.
 
 ### D. Usunięcie cache'u i przyspieszenie szablonów
 
@@ -181,7 +314,7 @@ W `flexible_reports/adapters/django_tables2.py`:
 
 1. Usuń `_table_cache` oraz `global _table_cache`; `_table()` buduje klasę przy
    każdym wywołaniu.
-2. Dodaj kompilację szablonu kolumny cache'owaną **treścią szablonu**:
+2. Dodaj kompilację szablonu cache'owaną **treścią szablonu**:
 
 ```python
 @lru_cache(maxsize=512)
@@ -189,21 +322,55 @@ def _compiled_template(template_code):
     return Template(template_code)
 ```
 
-3. `DjangoTables2TemplateColumn` nadpisuje `render()`, używając
-   `_compiled_template(self.template_code)` zamiast `Template(self.template_code)`.
-   Gdy kolumna nie ma `template_code` (tylko `template_name`), deleguje do
-   `super().render(...)`.
+3. `DjangoTables2TemplateColumn` nadpisuje `render()`.
+
+**Override musi odtworzyć ciało metody rodzica dosłownie, zmieniając wyłącznie
+`Template(self.template_code)` na `_compiled_template(self.template_code)`.**
+Rodzic (`django_tables2/columns/templatecolumn.py:104-120`) robi cztery rzeczy,
+z których żadnej nie wolno pominąć:
+
+1. `parent_context = getattr(table, "context", Context())` — dziedziczy kontekst
+   strony podpięty przez `{% render_table %}`;
+2. `self.get_context_data(...)` — dostarcza `default`, `column`, `record` (pod
+   `context_object_name`), `value`, `row_counter` oraz scalony `extra_context`
+   (również gdy jest callable);
+3. `with parent_context.update(context):` — to **context manager**, więc zmienne
+   komórki są *zdejmowane* po jej wyrenderowaniu; pominięcie tego przecieka
+   zmienne z jednej komórki do następnej;
+4. `parent_context["request"] = request` wewnątrz tego bloku, z
+   `getattr(table, "request", None)`.
+
+Gdy kolumna nie ma `template_code` (tylko `template_name`), delegujemy do
+`super().render(...)`. Analogicznie delegujemy, gdy `self` nie ma
+`get_context_data` — `pyproject.toml` deklaruje `django-tables2>=1.16.0`, a ta
+metoda jest nowsza; fallback do `super().render()` zachowuje poprawność na
+starych wersjach kosztem optymalizacji, bez podnoszenia dolnego progu zależności.
+
+4. `FooterMixin._render_footer` (`adapters/django_tables2.py:60`) też przechodzi
+   na `_compiled_template`. Kompiluje raz na render, nie raz na komórkę, więc
+   zysk jest mały — ale zostawienie tam gołego `Template()` byłoby niespójne.
 
 **Skompilowanego `Template` nie wolno przypinać do obiektu kolumny.** Kolumny
-żyją w `Table.base_columns` i są deepcopy'owane przy każdej instancjacji tabeli;
-`Template` trzyma referencję do `engine`, więc deepcopy sklonowałby cały graf
-silnika szablonów wraz z loaderami i bibliotekami tagów. Zamiast przyspieszenia
-dałoby to regres. Cache modułowy kluczowany treścią omija ten problem w całości.
+żyją w `Table.base_columns` i są deepcopy'owane przy każdej instancjacji tabeli
+(`tables.py:318`; komentarz `CounterMixin`, `adapters/django_tables2.py:30-35`,
+już dokumentuje ten deepcopy). `Template` trzyma referencję do `engine`, więc
+deepcopy sklonowałby cały graf silnika szablonów wraz z loaderami i bibliotekami
+tagów. Zamiast przyspieszenia dałoby to regres. Cache modułowy kluczowany treścią
+omija ten problem w całości.
 
 Cache kluczowany treścią nie wymaga inwalidacji z definicji: zmiana szablonu w
 bazie daje inny string, więc inny klucz. `maxsize=512` ogranicza wzrost przy
-wielokrotnej edycji szablonów. Współdzielenie skompilowanych `Template` między
-wątkami jest bezpieczne — dokładnie tak działa `cached.Loader` w Django.
+wielokrotnej edycji szablonów. `Template(code)` rozwiązuje `Engine.get_default()`
+w momencie **wywołania**, nie importu, więc nie wprowadzamy zależności od
+kolejności importów. `lru_cache` w CPythonie jest bezpieczny wątkowo (najgorszy
+przypadek to podwójna kompilacja — nieszkodliwa), a współdzielenie skompilowanych
+`Template` między wątkami jest dokładnie tym, co robi `cached.Loader` w Django.
+
+**Zastrzeżenie:** zacache'owane `Template` zapamiętują silnik aktywny w chwili
+kompilacji. Pod `override_settings(TEMPLATES=...)` cache serwowałby szablony
+związane ze starym silnikiem, a stan przeciekałby między testami. Udostępniamy
+`_compiled_template.cache_clear()` i wołamy je w autouse-fixture w testach, żeby
+nie gonić fantomowych flaków.
 
 ## Testy
 
@@ -212,35 +379,65 @@ zobaczyć, że zawodzi z właściwego powodu.
 
 Konwencja repo: `pytest`, `pytest-django`, `model_bakery`, fixture `admin_client`,
 testy w `test_app/tests/test_models/` i `test_app/tests/test_admin/`.
+Baza: Postgres (patrz `tests/settings.py`).
 
-| Test | Plik | Co pilnuje |
-|---|---|---|
-| `test_clone_table_copies_columns` | `test_models/test_cloning.py` | liczba i wartości pól kolumn |
-| `test_clone_table_remaps_column_order` | `test_models/test_cloning.py` | `ColumnOrder` klonu wskazuje na kolumny klonu, nie oryginału |
-| `test_clone_table_is_independent` | `test_models/test_cloning.py` | edycja kolumny klonu nie zmienia oryginału |
-| `test_clone_table_label_is_numbered` | `test_models/test_cloning.py` | drugi klon dostaje `(kopia 2)` |
-| `test_clone_report_shares_tables` | `test_models/test_cloning.py` | element klonu ma to samo `table_id` i `datasource_id` |
-| `test_clone_report_copies_elements` | `test_models/test_cloning.py` | liczba elementów, zachowane slugi elementów |
-| `test_clone_report_unique_slug` | `test_models/test_cloning.py` | slug klonu różny od oryginału i nieprzekraczający `max_length` |
-| `test_clone_button_visible` | `test_admin/test_cloning.py` | przycisk obecny na formularzu edycji |
-| `test_clone_requires_post` | `test_admin/test_cloning.py` | GET -> 405, obiekt nie powstaje |
-| `test_clone_requires_add_permission` | `test_admin/test_cloning.py` | user bez `add` -> 403 |
-| `test_clone_missing_object_404` | `test_admin/test_cloning.py` | nieistniejące `object_id` -> 404 |
-| `test_clone_redirects_to_clone` | `test_admin/test_cloning.py` | przekierowanie na edycję klonu, nie oryginału |
-| `test_label_change_visible_without_restart` | `test_app/tests/test_adapters.py` | **regresja na cache**: zmiana `Column.label` widoczna w kolejnym renderze w tym samym procesie |
-| `test_removed_column_disappears` | `test_app/tests/test_adapters.py` | **regresja na cache**: usunięta kolumna znika z renderu |
+### Klonowanie — modele (`test_models/test_cloning.py`)
 
-Dwa ostatnie testy nie przechodzą na obecnym kodzie — pisane jako pierwsze.
+| Test | Co pilnuje |
+|---|---|
+| `test_clone_table_copies_columns` | liczba i wartości pól kolumn |
+| `test_clone_table_remaps_column_order` | `ColumnOrder` klonu wskazuje na kolumny klonu **oraz** na tabelę-klon (`columnorder.table == clone`) |
+| `test_clone_table_does_not_touch_source` | `original.pk` i PK oryginalnych kolumn niezmienione po `clone()`; działa też na instancji z `prefetch_related("column_set")` |
+| `test_clone_table_is_independent` | edycja kolumny klonu nie zmienia oryginału |
+| `test_clone_table_label_is_numbered` | drugi klon dostaje `(copy 2)`, nie `(copy) (copy)` |
+| `test_clone_report_shares_tables` | element klonu ma to samo `table_id` i `datasource_id` |
+| `test_clone_report_copies_elements` | liczba elementów, zachowane slugi elementów |
+| `test_clone_report_handles_except_catchall` | element z `datasource=None` i ustawionym `base_model` klonuje się poprawnie |
+| `test_clone_report_unique_slug` | slug klonu różny od oryginału; **przypadek brzegowy: slug źródłowy dokładnie 50 znaków**, żeby realnie wymusić skracanie rdzenia |
+
+### Klonowanie — admin (`test_admin/test_cloning.py`)
+
+| Test | Co pilnuje |
+|---|---|
+| `test_clone_button_visible` | przycisk obecny na formularzu edycji |
+| `test_clone_url_not_swallowed_by_catchall` | POST na `<pk>/clone/` trafia w nasz widok, a nie w RedirectView (regresja na kolejność `get_urls`) |
+| `test_clone_requires_post` | GET jako zalogowany admin -> 405, obiekt nie powstaje |
+| `test_clone_requires_add_permission` | user bez `add` -> 403 |
+| `test_clone_requires_view_permission` | user bez `view` na źródle -> 403 |
+| `test_clone_missing_object_404` | nieistniejące `object_id` -> 404 |
+| `test_clone_redirects_to_clone` | przekierowanie na edycję klonu, nie oryginału |
+| `test_clone_logs_addition` | powstaje `LogEntry` typu ADDITION dla klonu |
+
+### Cache i render (`test_app/tests/test_adapters.py`)
+
+| Test | Co pilnuje |
+|---|---|
+| `test_label_change_visible_without_restart` | **regresja**: zmiana `Column.label` widoczna w kolejnym renderze w tym samym procesie |
+| `test_removed_column_disappears` | **regresja**: usunięta kolumna znika z renderu |
+| `test_template_column_context_is_complete` | **najważniejszy dla override'u `render()`**: kolumna z szablonem używającym `{{ row_counter }}`, `{{ record }}` i zmiennej z kontekstu strony; asercje na **wielu wierszach**, żeby wymusić poprawne `row_counter` i zdejmowanie zmiennych przez context manager |
+| `test_no_template_pinned_to_column` | **regresja na deepcopy**: po renderze żadna kolumna w `base_columns` nie ma w `vars()` instancji `django.template.base.Template` |
+| `test_compiled_template_cache_is_used` | `_compiled_template.cache_info().hits` rośnie między dwoma renderami — dowód, że cache jest realnie na ścieżce gorącej |
+| `test_concurrent_render` | dwa wątki renderujące tę samą tabelę dają identyczny HTML bez wyjątków (ścieżka współdzielonego `Template`/`lru_cache`) |
+
+Testy `test_label_change_visible_without_restart` i `test_removed_column_disappears`
+nie przechodzą na obecnym kodzie — pisane jako pierwsze.
 
 ## Poza zakresem
 
 - Głębokie klonowanie raportu (wraz z tabelami).
 - Klonowanie `Datasource`.
 - Akcja masowego klonowania na changeliście.
-- Pole `Table.modified` i migracja — patrz "Odrzucone alternatywy".
+- Pole `Table.modified` i migracja — patrz „Odrzucone alternatywy".
+- Naprawa `docker-compose.yml` (brak `POSTGRES_HOST_AUTH_METHOD: trust`, przez co
+  kontener nie startuje z nowoczesnym obrazem postgresa) — realny błąd, ale
+  niezwiązany z tą zmianą.
 
 ## Dokumentacja
 
 Wpis w `HISTORY.rst` w sekcji dla kolejnego wydania: dwie nowe funkcje
 (klonowanie tabeli i raportu) oraz poprawka błędu z cache'em, z wyraźnym
-zaznaczeniem, że zmiany etykiet nie wymagają już restartu.
+zaznaczeniem, że zmiany etykiet nie wymagają już restartu. Odnotować też
+niezweryfikowaną kompatybilność przycisku z grappelli.
+
+Nowy msgid `"copy"` z tłumaczeniem `"kopia"` w
+`flexible_reports/locale/pl/LC_MESSAGES/django.po`.

--- a/docs/superpowers/specs/2026-07-22-cloning-and-cache-design.md
+++ b/docs/superpowers/specs/2026-07-22-cloning-and-cache-design.md
@@ -1,0 +1,246 @@
+# Klonowanie tabel i raportów + usunięcie cache'u tabel
+
+Data: 2026-07-22
+Status: zaakceptowana
+
+## Cel
+
+Trzy niezależne zmiany w `django-flexible-reports`:
+
+1. Możliwość sklonowania `Table` (wraz z kolumnami i kolejnością sortowania).
+2. Możliwość sklonowania `Report` (wraz z jego elementami).
+3. Naprawa błędu: zmiana `label` w bazie nie jest widoczna bez restartu procesu
+   Django.
+
+## Kontekst — diagnoza błędu z punktu 3
+
+`flexible_reports/adapters/django_tables2.py` trzyma moduł-globalny słownik:
+
+```python
+_table_cache = {}
+
+def _table(table):
+    global _table_cache
+    if table.pk not in _table_cache:
+        ...
+        _table_cache[table.pk] = AdHocTable
+    return _table_cache[table.pk]
+```
+
+Cache jest kluczowany wyłącznie po `table.pk` i **nie ma żadnej inwalidacji**.
+Raz zbudowana klasa `AdHocTable` — zawierająca `verbose_name` kolumn, `attrs`,
+`empty_text`, `order_by` i `prefix` — żyje do końca procesu. Wprowadził to
+commit `40d9da4 "Speedups"`.
+
+Konsekwencje:
+
+- Zmiana `Column.label` lub `Table.label` wymaga restartu procesu.
+- Usunięcie kolumny również nie działa — `base_columns` zapamiętanej klasy nadal
+  ją zawiera.
+- Przy wielu workerach zachowanie jest niedeterministyczne: edycja w adminie
+  trafia do jednego procesu, pozostałe serwują stare nagłówki. Użytkownik widzi
+  raz stare, raz nowe dane, zależnie od tego, który worker obsłuży żądanie.
+  Z tego powodu inwalidacja sygnałem `post_save` w pamięci procesu **nie
+  wystarcza** — naprawiłaby tylko jeden worker.
+
+### Pomiar: ile ten cache jest wart
+
+Benchmark na tabeli 8 kolumn typu `TemplateColumn` z szablonem `{{ value }}`
+(sqlite in-memory, Python 3.13, django-tables2 z `.venv`):
+
+| | 20 wierszy | 100 | 500 | 1000 |
+|---|---|---|---|---|
+| Budowa klasy `AdHocTable` (to, co cache oszczędza) | 0,48 ms | 0,46 ms | 0,46 ms | 0,45 ms |
+| Instancjacja (`deepcopy base_columns`, zawsze) | 0,22 ms | 0,20 ms | 0,18 ms | 0,17 ms |
+| Pełny render tabeli do HTML | 6,4 ms | 30,5 ms | 172,7 ms | 312,6 ms |
+| **Udział cache'u w renderze** | 7,4% | 1,5% | 0,27% | 0,14% |
+
+Oszczędność jest stała (~0,46 ms + 2 zapytania SQL), a koszt renderu rośnie
+liniowo z liczbą wierszy. Im większy raport, tym cache mniej znaczy.
+
+Powód jest strukturalny, potwierdzony w źródłach `django_tables2`:
+
+- `Table.__init__` (`tables.py:318`) wykonuje `copy.deepcopy(type(self).base_columns)`
+  przy **każdej** instancjacji. Zapamiętanie klasy nie omija tego deepcopy.
+- `TemplateColumn.render()` (`columns/templatecolumn.py`) wykonuje
+  `Template(self.template_code)` przy **każdej komórce**. Dla tabeli 500×8 to
+  4000 kompilacji szablonu na jeden render; cache klasy nie eliminuje z tego nic.
+
+### Prawdziwy hot-spot
+
+Prototyp kompilujący szablon raz zamiast per komórka, ta sama tabela 500×8:
+
+```
+Render obecny (kompilacja per komórka):     151,4 ms
+Render z szablonem kompilowanym raz:        113,3 ms
+  -> 1,34x szybciej (oszczędność 38,1 ms)
+
+Dla porównania _table_cache oszczędza:         0,46 ms
+```
+
+Zysk jest ~83x większy niż z cache'u, który psuje nagłówki — i to przy
+najprostszym możliwym szablonie. Przy bogatszych szablonach różnica rośnie,
+bo kompilacja jest droższa.
+
+### Decyzja
+
+Usuwamy `_table_cache` całkowicie i w zamian cache'ujemy kompilację szablonu
+kolumny. Netto render będzie **szybszy niż obecnie**, mimo usunięcia cache'u,
+a nagłówki będą zawsze świeże we wszystkich procesach.
+
+Odrzucone alternatywy:
+
+- **Inwalidacja sygnałem `post_save`** — nie działa przy wielu workerach.
+- **Klucz wersjonowany `(pk, Table.modified)`** — poprawne między procesami, ale
+  wymaga nowego pola, migracji i sygnałów z `Column`/`ColumnOrder`, żeby
+  uratować 0,46 ms. Nadinżynieria wobec zmierzonych liczb.
+
+## Zakres zmian
+
+### A. `Table.clone()`
+
+Nowy moduł `flexible_reports/models/cloning.py` z helperami nazewniczymi;
+metoda `clone()` na modelu. Logika mieszka w modelu, admin ją tylko wywołuje —
+dzięki temu klonowanie działa też ze skryptu i z shella oraz testuje się bez
+warstwy HTTP.
+
+Algorytm (cały w `transaction.atomic`):
+
+1. Wczytaj do pamięci `column_set` i `columnorder_set` **przed** zmianą PK.
+2. Skopiuj `Table` (`pk = None`, `_state.adding = True`), ustaw nową etykietę.
+3. Skopiuj kolumny, budując mapę `stare_pk -> nowy obiekt Column`.
+4. Skopiuj `ColumnOrder`, przepinając pole `column` przez tę mapę.
+5. Zwróć nowy obiekt.
+
+Krok 4 jest krytyczny: `ColumnOrder` ma FK zarówno do `Table`, jak i do
+`Column`. Bez przepięcia klon sortowałby się po kolumnach oryginału, co jest
+cichym błędem — tabela renderuje się poprawnie, tylko w złej kolejności, i
+psuje się dopiero przy edycji kolumn oryginału.
+
+Nazwa klonu: `label` -> `"X (kopia)"`, przy kolejnych klonach `"X (kopia 2)"`,
+`"X (kopia 3)"`. `Table.label` nie ma ograniczenia unikalności, więc numerowanie
+jest wyłącznie kosmetyczne — ale bez niego lista wyboru tabeli w
+`ReportElement` wypełnia się nierozróżnialnymi pozycjami.
+
+### B. `Report.clone()`
+
+Klonowanie **płytkie**: nowy `Report` i nowe `ReportElement`-y wskazujące na
+**te same** obiekty `Table` i `Datasource`. Głębokie klonowanie odrzucono —
+mnożyłoby w adminie w większości identyczne tabele. Kto chce niezależnej
+tabeli, klonuje ją osobno (punkt A) i przepina element.
+
+- `title` -> `"X (kopia)"`, analogicznie do `Table.label`.
+- `template` kopiowany dosłownie.
+- `slug` -> unikalny w obrębie `Report` (`x-kopia`, `x-kopia-2`), z pilnowaniem
+  `max_length` pola `SlugField`.
+- Slugi `ReportElement` pozostają **bez zmian**.
+
+Uzasadnienie unikalności sluga raportu: `Report.slug` nie ma `unique=True` i nie
+jest używany w URL-ach tego pakietu (`urls.py` jest pusty), ale projekty
+konsumujące niemal na pewno robią `Report.objects.get(slug=...)`. Klon z
+identycznym slugiem wywołałby u nich `MultipleObjectsReturned`.
+
+Uzasadnienie niezmienności slugów elementów: `unique_together` to
+`('parent', 'slug')`, więc pod nowym rodzicem nie kolidują, a szablon raportu
+adresuje elementy przez `{{ elements.jakis_slug }}`. Zmiana slugów rozspójniłaby
+skopiowany szablon z elementami.
+
+### C. Admin — przycisk w formularzu edycji
+
+Wspólny `CloneAdminMixin` w `flexible_reports/admin/cloning.py`, podpięty pod
+`TableAdmin` i `ReportAdmin`.
+
+- `get_urls()` dokłada trasę `<path:object_id>/clone/` o nazwie
+  `flexible_reports_<model>_clone`.
+- Widok przyjmuje **wyłącznie POST** (`require_POST`). Klonowanie zmienia stan
+  bazy, więc zwykły link `<a href>` pozwoliłby stworzyć obiekt przez
+  `<img src="...">` osadzony w obcej stronie. Formularz daje CSRF za darmo.
+- Uprawnienia: wymagane `has_add_permission` (tworzymy obiekt) **oraz**
+  `has_view_permission` na obiekcie źródłowym. Brak któregokolwiek -> 403.
+- Nieistniejące `object_id` -> 404.
+- Po sklonowaniu: `log_addition()` (wpis w historii admina),
+  `message_user(..., messages.SUCCESS)` i przekierowanie na formularz edycji
+  **klonu**, nie oryginału.
+
+Szablon `flexible_reports/templates/admin/flexible_reports/change_form_with_clone.html`
+rozszerza `admin/change_form.html` i nadpisuje `{% block object-tools-items %}`,
+dokładając `{{ block.super }}` oraz `<li>` z małym formularzem POST.
+
+Weryfikacja: w `admin/change_form.html` (Django z `.venv`) blok
+`object-tools-items` jest w linii 31, a główny `<form>` otwiera się dopiero w
+linii 36 — nasz formularz nie zagnieżdża się więc w cudzym, co byłoby
+niepoprawnym HTML-em.
+
+Admin ustawia `change_form_template` na powyższy szablon. `TableAdmin` i
+`ReportAdmin` nie definiują dziś własnego `change_form_template`, więc nic nie
+nadpisujemy.
+
+### D. Usunięcie cache'u i przyspieszenie szablonów
+
+W `flexible_reports/adapters/django_tables2.py`:
+
+1. Usuń `_table_cache` oraz `global _table_cache`; `_table()` buduje klasę przy
+   każdym wywołaniu.
+2. Dodaj kompilację szablonu kolumny cache'owaną **treścią szablonu**:
+
+```python
+@lru_cache(maxsize=512)
+def _compiled_template(template_code):
+    return Template(template_code)
+```
+
+3. `DjangoTables2TemplateColumn` nadpisuje `render()`, używając
+   `_compiled_template(self.template_code)` zamiast `Template(self.template_code)`.
+   Gdy kolumna nie ma `template_code` (tylko `template_name`), deleguje do
+   `super().render(...)`.
+
+**Skompilowanego `Template` nie wolno przypinać do obiektu kolumny.** Kolumny
+żyją w `Table.base_columns` i są deepcopy'owane przy każdej instancjacji tabeli;
+`Template` trzyma referencję do `engine`, więc deepcopy sklonowałby cały graf
+silnika szablonów wraz z loaderami i bibliotekami tagów. Zamiast przyspieszenia
+dałoby to regres. Cache modułowy kluczowany treścią omija ten problem w całości.
+
+Cache kluczowany treścią nie wymaga inwalidacji z definicji: zmiana szablonu w
+bazie daje inny string, więc inny klucz. `maxsize=512` ogranicza wzrost przy
+wielokrotnej edycji szablonów. Współdzielenie skompilowanych `Template` między
+wątkami jest bezpieczne — dokładnie tak działa `cached.Loader` w Django.
+
+## Testy
+
+Podejście TDD: każdy test pisany przed implementacją i uruchamiany, żeby
+zobaczyć, że zawodzi z właściwego powodu.
+
+Konwencja repo: `pytest`, `pytest-django`, `model_bakery`, fixture `admin_client`,
+testy w `test_app/tests/test_models/` i `test_app/tests/test_admin/`.
+
+| Test | Plik | Co pilnuje |
+|---|---|---|
+| `test_clone_table_copies_columns` | `test_models/test_cloning.py` | liczba i wartości pól kolumn |
+| `test_clone_table_remaps_column_order` | `test_models/test_cloning.py` | `ColumnOrder` klonu wskazuje na kolumny klonu, nie oryginału |
+| `test_clone_table_is_independent` | `test_models/test_cloning.py` | edycja kolumny klonu nie zmienia oryginału |
+| `test_clone_table_label_is_numbered` | `test_models/test_cloning.py` | drugi klon dostaje `(kopia 2)` |
+| `test_clone_report_shares_tables` | `test_models/test_cloning.py` | element klonu ma to samo `table_id` i `datasource_id` |
+| `test_clone_report_copies_elements` | `test_models/test_cloning.py` | liczba elementów, zachowane slugi elementów |
+| `test_clone_report_unique_slug` | `test_models/test_cloning.py` | slug klonu różny od oryginału i nieprzekraczający `max_length` |
+| `test_clone_button_visible` | `test_admin/test_cloning.py` | przycisk obecny na formularzu edycji |
+| `test_clone_requires_post` | `test_admin/test_cloning.py` | GET -> 405, obiekt nie powstaje |
+| `test_clone_requires_add_permission` | `test_admin/test_cloning.py` | user bez `add` -> 403 |
+| `test_clone_missing_object_404` | `test_admin/test_cloning.py` | nieistniejące `object_id` -> 404 |
+| `test_clone_redirects_to_clone` | `test_admin/test_cloning.py` | przekierowanie na edycję klonu, nie oryginału |
+| `test_label_change_visible_without_restart` | `test_app/tests/test_adapters.py` | **regresja na cache**: zmiana `Column.label` widoczna w kolejnym renderze w tym samym procesie |
+| `test_removed_column_disappears` | `test_app/tests/test_adapters.py` | **regresja na cache**: usunięta kolumna znika z renderu |
+
+Dwa ostatnie testy nie przechodzą na obecnym kodzie — pisane jako pierwsze.
+
+## Poza zakresem
+
+- Głębokie klonowanie raportu (wraz z tabelami).
+- Klonowanie `Datasource`.
+- Akcja masowego klonowania na changeliście.
+- Pole `Table.modified` i migracja — patrz "Odrzucone alternatywy".
+
+## Dokumentacja
+
+Wpis w `HISTORY.rst` w sekcji dla kolejnego wydania: dwie nowe funkcje
+(klonowanie tabeli i raportu) oraz poprawka błędu z cache'em, z wyraźnym
+zaznaczeniem, że zmiany etykiet nie wymagają już restartu.

--- a/flexible_reports/adapters/django_tables2.py
+++ b/flexible_reports/adapters/django_tables2.py
@@ -3,7 +3,7 @@ import copy
 import operator
 import sys
 from collections import OrderedDict, defaultdict
-from functools import reduce
+from functools import lru_cache, reduce
 from tempfile import NamedTemporaryFile
 
 import bleach
@@ -23,6 +23,26 @@ from django_tables2.tables import Table
 from tablib.core import Databook, Dataset
 
 from flexible_reports.models.report import DATA_FROM_DATASOURCE
+
+
+@lru_cache(maxsize=512)
+def _compiled_template(template_code):
+    """Compile a template once per distinct template source.
+
+    ``TemplateColumn.render`` compiles its template for every single cell,
+    which dominates the cost of rendering a large table. The cache is keyed by
+    the template source, so it needs no invalidation: editing a template in the
+    database produces a different string, hence a different key.
+
+    The compiled ``Template`` must never be pinned onto a column instance:
+    columns live in ``Table.base_columns`` and are deep-copied on every table
+    instantiation, and a ``Template`` holds a reference to the template engine.
+
+    ``cache_clear()`` is available for tests that swap the template engine with
+    ``override_settings(TEMPLATES=...)``, as a cached ``Template`` remembers the
+    engine active at compilation time.
+    """
+    return Template(template_code)
 
 
 class CounterMixin:
@@ -57,7 +77,7 @@ class FooterMixin:
 
         context = Context({"value": value, "error": error, "count": len(table.data)})
 
-        return Template(self.footer_template).render(context=context)
+        return _compiled_template(self.footer_template).render(context=context)
 
 
 class StripHTMLOnExportMixin:
@@ -81,6 +101,39 @@ class DjangoTables2TemplateColumn(
         StripHTMLOnExportMixin.__init__(self, strip_html_on_export)
         CounterMixin.__init__(self)
         TemplateColumn.__init__(self, *args, **kw)
+
+    def render(self, record, table, value, bound_column, **kwargs):
+        # This is the body of ``TemplateColumn.render``, with the per-cell
+        # ``Template(self.template_code)`` compilation replaced by the
+        # module-level, content-keyed cache.
+        #
+        # Columns rendering a template file (``template_name``) go through the
+        # parent, and so do old django-tables2 releases without
+        # ``get_context_data`` -- ``pyproject.toml`` only requires
+        # ``django-tables2>=1.16.0``, which predates that method.
+        if not self.template_code or not hasattr(self, "get_context_data"):
+            return super().render(
+                record=record,
+                table=table,
+                value=value,
+                bound_column=bound_column,
+                **kwargs,
+            )
+
+        # If the table is being rendered using `render_table`, it hackily
+        # attaches the context to the table as a gift to `TemplateColumn`.
+        parent_context = getattr(table, "context", Context())
+
+        context = self.get_context_data(
+            record=record, table=table, value=value, bound_column=bound_column, **kwargs
+        )
+        # ``update`` is used as a context manager on purpose: the cell
+        # variables have to be popped again once the cell has been rendered,
+        # otherwise they leak into the next cell.
+        with parent_context.update(context):
+            request = getattr(table, "request", None)
+            parent_context["request"] = request
+            return _compiled_template(self.template_code).render(parent_context)
 
 
 class DjangoTables2Column(StripHTMLOnExportMixin, FooterMixin, Column):
@@ -114,35 +167,31 @@ def column(column):
     return (column.label, klass)
 
 
-_table_cache = {}
-
-
 def _table(table):
-    global _table_cache
+    # The class is rebuilt on every call. It used to be cached per ``Table.pk``
+    # for the lifetime of the process, which made label changes and removed
+    # columns invisible until a restart. The cache saved ~0.5 ms per render,
+    # far less than caching the compiled column templates does.
+    order_by = []
+    for column_order in (
+        table.columnorder_set.all().select_related().order_by("position")
+    ):
+        order_by.append(column_order.get())
+    table.order_by = order_by
 
-    if table.pk not in _table_cache:
-        order_by = []
-        for column_order in (
-            table.columnorder_set.all().select_related().order_by("position")
-        ):
-            order_by.append(column_order.get())
-        table.order_by = order_by
+    class AdHocTable(Table):
+        class Meta:
+            attrs = table.attrs or {}
+            order_by = table.order_by
+            per_page = sys.maxsize
+            prefix = table.get_prefix()
+            empty_text = mark_safe(table.empty_template)
 
-        class AdHocTable(Table):
-            class Meta:
-                attrs = table.attrs or {}
-                order_by = table.order_by
-                per_page = sys.maxsize
-                prefix = table.get_prefix()
-                empty_text = mark_safe(table.empty_template)
+    for c in table.column_set.all():
+        label, klass = column(c)
+        AdHocTable.base_columns[label] = klass
 
-        for c in table.column_set.all():
-            label, klass = column(c)
-            AdHocTable.base_columns[label] = klass
-
-        _table_cache[table.pk] = AdHocTable
-
-    return _table_cache[table.pk]
+    return AdHocTable
 
 
 def table(table, request, object_list):

--- a/flexible_reports/admin/__init__.py
+++ b/flexible_reports/admin/__init__.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 
+from .cloning import *  # noqa
 from .datasource import *  # noqa
 from .report import *  # noqa
 from .table import *  # noqa

--- a/flexible_reports/admin/cloning.py
+++ b/flexible_reports/admin/cloning.py
@@ -1,0 +1,98 @@
+# -*- encoding: utf-8 -*-
+
+"""Admin glue exposing ``Table.clone()`` and ``Report.clone()`` as a button.
+
+The cloning logic itself lives on the models; this module only wires it into
+the change form of a ``ModelAdmin``.
+"""
+
+from django.contrib import messages
+from django.contrib.admin.utils import unquote
+from django.core.exceptions import PermissionDenied
+from django.http import Http404, HttpResponseRedirect
+from django.urls import path, reverse
+from django.views.decorators.http import require_POST
+
+try:
+    from django.utils.translation import gettext_lazy as _
+except ImportError:  # pragma: no cover
+    from django.utils.translation import ugettext_lazy as _
+
+__all__ = ["CloneAdminMixin"]
+
+
+class CloneAdminMixin:
+    """Adds a "Clone" button to the change form of a model with ``clone()``."""
+
+    change_form_template = "admin/flexible_reports/change_form_with_clone.html"
+
+    def get_urls(self):
+        info = self.opts.app_label, self.opts.model_name
+        my_urls = [
+            path(
+                "<path:object_id>/clone/",
+                # ``require_POST`` cannot be used as a decorator in the class
+                # body: its wrapper is ``inner(request, *args, **kwargs)``, so
+                # on an unbound method ``request`` would bind to ``self`` and
+                # blow up with an AttributeError instead of returning 405.
+                # Here it wraps the *bound* method.
+                #
+                # ``admin_view`` has to stay on the *outside* so that an
+                # anonymous GET is redirected to the login page rather than
+                # told 405 (which leaks the existence of the URL); it also
+                # adds the ``is_staff`` check, ``never_cache`` and session
+                # handling.
+                self.admin_site.admin_view(require_POST(self.clone_view)),
+                name="%s_%s_clone" % info,
+            ),
+        ]
+        # Our routes must come *first*. ``ModelAdmin.get_urls()`` ends with a
+        # backwards-compatibility catch-all ``<path:object_id>/`` and the
+        # ``path:`` converter matches slashes, so appending our route would
+        # leave it dead: ``<pk>/clone/`` would be swallowed as
+        # ``object_id="<pk>/clone"`` and redirected into a 404.
+        return my_urls + super().get_urls()
+
+    def clone_view(self, request, object_id):
+        # A clone is a brand new object, hence ``add``; ``view`` is required on
+        # the source. ``change`` on the source deliberately is not -- this
+        # matches the built-in "save as new".
+        if not self.has_add_permission(request):
+            raise PermissionDenied
+
+        obj = self.get_object(request, unquote(object_id))
+        if obj is None:
+            raise Http404(
+                _("%(name)s object with primary key %(key)r does not exist.")
+                % {"name": self.opts.verbose_name, "key": object_id}
+            )
+
+        if not self.has_view_permission(request, obj):
+            raise PermissionDenied
+
+        new_obj = obj.clone()
+
+        # ``message`` is a required argument, and this structure is what makes
+        # the history page render "Added." instead of a raw string.
+        self.log_addition(request, new_obj, [{"added": {}}])
+        self.message_user(
+            request,
+            _('Cloned to "%(obj)s".') % {"obj": new_obj},
+            messages.SUCCESS,
+        )
+
+        info = self.opts.app_label, self.opts.model_name
+        if self.has_change_permission(request, new_obj):
+            url = reverse(
+                "admin:%s_%s_change" % info,
+                args=(new_obj.pk,),
+                current_app=self.admin_site.name,
+            )
+        else:
+            # Sending the user to a change form they may not open would turn a
+            # successful action into a 403; mirrors _response_post_save().
+            url = reverse(
+                "admin:%s_%s_changelist" % info,
+                current_app=self.admin_site.name,
+            )
+        return HttpResponseRedirect(url)

--- a/flexible_reports/admin/report.py
+++ b/flexible_reports/admin/report.py
@@ -11,6 +11,7 @@ from flexible_reports.admin.helpers import BiggerTextarea
 
 from ..models import Report
 from ..models.report import ReportElement
+from .cloning import CloneAdminMixin
 from .helpers import SmallerTextarea, SortableHiddenMixin
 
 
@@ -51,7 +52,7 @@ class ReportForm(forms.ModelForm):
 
 
 @admin.register(Report)
-class ReportAdmin(admin.ModelAdmin):
+class ReportAdmin(CloneAdminMixin, admin.ModelAdmin):
     list_display = ["title", "slug", "elements"]
     inlines = [
         ReportElementInline,

--- a/flexible_reports/admin/table.py
+++ b/flexible_reports/admin/table.py
@@ -11,6 +11,7 @@ except ImportError:
 from flexible_reports.models.table import AllSortOptions, SortInGroup
 
 from ..models import Column, ColumnOrder, Table
+from .cloning import CloneAdminMixin
 from .helpers import AverageTextarea, SmallerTextarea, SortableHiddenMixin
 
 
@@ -86,7 +87,7 @@ class TableForm(forms.ModelForm):
 
 
 @admin.register(Table)
-class TableAdmin(admin.ModelAdmin):
+class TableAdmin(CloneAdminMixin, admin.ModelAdmin):
     list_display = ["label", "base_model", "short_sort_option", "columns"]
     inlines = [ColumnInline, ColumnOrderInline]
     form = TableForm

--- a/flexible_reports/locale/pl/LC_MESSAGES/django.po
+++ b/flexible_reports/locale/pl/LC_MESSAGES/django.po
@@ -65,6 +65,10 @@ msgstr "Tytuł"
 msgid "Position"
 msgstr "Pozycja"
 
+#: flexible_reports/models/cloning.py:39
+msgid "copy"
+msgstr "kopia"
+
 #: flexible_reports/models/column.py:14
 msgid "Sortable"
 msgstr "Zezwalaj na sortowanie"

--- a/flexible_reports/locale/pl/LC_MESSAGES/django.po
+++ b/flexible_reports/locale/pl/LC_MESSAGES/django.po
@@ -19,6 +19,16 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.0.4\n"
 
+#: flexible_reports/admin/cloning.py:66
+#, python-format
+msgid "%(name)s object with primary key %(key)r does not exist."
+msgstr "Obiekt %(name)s o kluczu głównym %(key)r nie istnieje."
+
+#: flexible_reports/admin/cloning.py:80
+#, python-format
+msgid "Cloned to \"%(obj)s\"."
+msgstr "Sklonowano do „%(obj)s”."
+
 #: flexible_reports/admin/datasource.py:37
 #, python-format
 msgid ""
@@ -432,6 +442,10 @@ msgstr "Proszę wpisać prefiks grupy, jeżeli chcesz sortować tą tabelę w gr
 #, python-format
 msgid "Cannot compile template (%(exception)s)"
 msgstr "Nie mogę skompilować kodu templatki (wyjątek: %(exception)s)"
+
+#: flexible_reports/templates/admin/flexible_reports/change_form_with_clone.html:14
+msgid "Clone"
+msgstr "Klonuj"
 
 #~ msgid ""
 #~ "\n"

--- a/flexible_reports/models/__init__.py
+++ b/flexible_reports/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 
+from .cloning import *  # noqa
 from .column import *  # noqa
 from .datasource import *  # noqa
 from .report import *  # noqa

--- a/flexible_reports/models/cloning.py
+++ b/flexible_reports/models/cloning.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+"""Naming helpers shared by :meth:`Table.clone` and :meth:`Report.clone`.
+
+The suffix appended to a clone's name is translatable: the ``msgid`` is
+``"copy"``, so an English deployment gets ``"My table (copy)"`` and a Polish
+one ``"My table (kopia)"``.
+"""
+
+import re
+
+from django.utils.text import slugify
+
+try:
+    from django.utils.translation import gettext as _
+except ImportError:  # pragma: no cover
+    from django.utils.translation import ugettext as _
+
+__all__ = [
+    "copy_word",
+    "strip_copy_suffix",
+    "make_copy_label",
+    "next_free_label",
+    "strip_slug_copy_suffix",
+    "make_copy_slug",
+    "next_free_slug",
+]
+
+#: Fallback used when the active translation of ``"copy"`` slugifies to an
+#: empty string (a language written entirely in non-latin script).
+DEFAULT_SLUG_WORD = "copy"
+
+
+def copy_word():
+    """The translated word used to build clone names.
+
+    Resolved at call time, so it follows the currently active language.
+    """
+    return _("copy")
+
+
+def strip_copy_suffix(label):
+    """Strip a trailing ``" (copy)"`` / ``" (copy 7)"`` from ``label``.
+
+    Cloning a clone should give ``"X (copy 2)"``, not ``"X (copy) (copy)"``.
+    The pattern is built from the *current* translation, so a label produced
+    under a different active language will simply not match and we end up with
+    a nested suffix -- a cosmetic, accepted degradation.
+    """
+    pattern = re.compile(r"\s*\(%s(?:\s+\d+)?\)\s*$" % re.escape(copy_word()))
+    return pattern.sub("", label).strip()
+
+
+def make_copy_label(stem, number):
+    """``("X", 1) -> "X (copy)"``, ``("X", 2) -> "X (copy 2)"``."""
+    if number <= 1:
+        return "%s (%s)" % (stem, copy_word())
+    return "%s (%s %d)" % (stem, copy_word(), number)
+
+
+def next_free_label(queryset, field_name, value):
+    """First unused ``"<value> (copy N)"`` for ``field_name`` in ``queryset``.
+
+    The scan races: two concurrent clones can compute the same name. No field
+    involved has ``unique=True``, so nothing blows up -- we would simply end up
+    with two identically named objects. Cloning is a manual administrative
+    operation, so this is accepted.
+    """
+    stem = strip_copy_suffix(value)
+    number = 1
+    while True:
+        candidate = make_copy_label(stem, number)
+        if not queryset.filter(**{field_name: candidate}).exists():
+            return candidate
+        number += 1
+
+
+def _slug_copy_word():
+    return slugify(copy_word()) or DEFAULT_SLUG_WORD
+
+
+def strip_slug_copy_suffix(slug):
+    """Slug counterpart of :func:`strip_copy_suffix` (``-copy``, ``-copy-3``)."""
+    pattern = re.compile(r"-%s(?:-\d+)?$" % re.escape(_slug_copy_word()))
+    return pattern.sub("", slug)
+
+
+def make_copy_slug(stem, number, max_length):
+    """Append ``-copy`` / ``-copy-N`` to ``stem``, truncating the *stem*.
+
+    Truncating the whole string would chop the suffix off and make the clone's
+    slug collide with the source's again, so the stem is shortened to make room
+    for the suffix instead.
+    """
+    word = _slug_copy_word()
+    suffix = "-%s" % word if number <= 1 else "-%s-%d" % (word, number)
+    if max_length is not None:
+        stem = stem[: max(max_length - len(suffix), 0)].rstrip("-")
+    return "%s%s" % (stem, suffix)
+
+
+def next_free_slug(queryset, field_name, value, max_length):
+    """First unused ``"<value>-copy-N"`` for ``field_name`` in ``queryset``."""
+    stem = strip_slug_copy_suffix(value)
+    number = 1
+    while True:
+        candidate = make_copy_slug(stem, number, max_length)
+        if not queryset.filter(**{field_name: candidate}).exists():
+            return candidate
+        number += 1

--- a/flexible_reports/models/report.py
+++ b/flexible_reports/models/report.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.template.loader import get_template
 try:
     from django.utils.translation import gettext_lazy as _
@@ -9,6 +9,7 @@ except ImportError:
     from django.utils.translation import ugettext_lazy as _
 
 from .behaviors import Orderable, Titled
+from .cloning import next_free_label, next_free_slug
 from .validators import TemplateValidator
 
 DATA_FROM_DATASOURCE = 0
@@ -133,3 +134,45 @@ class Report(Titled):
 
     def set_context(self, context):
         self._context = context
+
+    def clone(self):
+        """Copy this report together with its elements.
+
+        Returns the newly created :class:`Report`.
+
+        The copy is *shallow*: the cloned elements point at the very same
+        :class:`~flexible_reports.models.table.Table` and
+        :class:`~flexible_reports.models.datasource.Datasource` rows. Whoever
+        needs an independent table clones that table separately and repoints
+        the element.
+
+        As in ``Table.clone()``, neither ``self`` nor anything reachable from
+        it is modified -- hence the fresh queryset for the elements instead of
+        the (possibly prefetch-cached) related manager.
+        """
+        with transaction.atomic():
+            elements = list(ReportElement.objects.filter(parent=self))
+
+            clone = Report.objects.get(pk=self.pk)
+            clone.pk = None
+            clone._state.adding = True
+            clone.title = next_free_label(Report.objects.all(), "title", self.title)
+            clone.slug = next_free_slug(
+                Report.objects.all(),
+                "slug",
+                self.slug,
+                self._meta.get_field("slug").max_length,
+            )
+            clone.save()
+
+            for element in elements:
+                element.pk = None
+                element._state.adding = True
+                element.parent = clone
+                # Element slugs stay as they are: ``unique_together`` is
+                # ``("parent", "slug")`` so they cannot collide under the new
+                # parent, and the copied report template addresses elements by
+                # slug -- renaming them would break it.
+                element.save()
+
+            return clone

--- a/flexible_reports/models/table.py
+++ b/flexible_reports/models/table.py
@@ -10,7 +10,7 @@ except ImportError:
     from django.contrib.postgres.fields.jsonb import JSONField
 
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.utils.text import format_lazy
 
 try:
@@ -19,6 +19,7 @@ except ImportError:
     from django.utils.translation import ugettext_lazy as _
 
 from .behaviors import Labelled, Orderable
+from .cloning import next_free_label
 
 
 class SortWithOtherTables:
@@ -156,3 +157,55 @@ class Table(Labelled):
 
     def get_prefix(self):
         return AllSortOptions[self.sort_option].get_prefix(None, self)
+
+    def clone(self):
+        """Copy this table together with its columns and sort order.
+
+        Returns the newly created :class:`Table`.
+
+        Neither ``self`` nor any object reachable from it is modified: after
+        the call ``self.pk`` is unchanged and a subsequent ``self.save()``
+        still updates the original. Children are therefore fetched with a
+        *fresh* queryset -- going through ``self.column_set`` would hand back
+        the instances cached by ``prefetch_related()``, and nulling their
+        primary keys would corrupt objects the caller still holds.
+
+        Reports using this table are deliberately left alone.
+        """
+        from .column import Column
+
+        with transaction.atomic():
+            columns = list(Column.objects.filter(parent=self))
+            column_orders = list(ColumnOrder.objects.filter(table=self))
+
+            clone = Table.objects.get(pk=self.pk)
+            clone.pk = None
+            clone._state.adding = True
+            clone.label = next_free_label(Table.objects.all(), "label", self.label)
+            clone.save()
+
+            # old Column pk -> freshly saved Column
+            column_map = {}
+            for column in columns:
+                old_pk = column.pk
+                column.pk = None
+                column._state.adding = True
+                column.parent = clone
+                column.save()
+                column_map[old_pk] = column
+
+            for column_order in column_orders:
+                old_column_id = column_order.column_id
+                column_order.pk = None
+                column_order._state.adding = True
+                # Both foreign keys have to be repointed. Without ``table``
+                # the entry would stay with the original and the clone would
+                # silently lose its ordering; without ``column`` the clone
+                # would sort by the original's columns.
+                column_order.table = clone
+                new_column = column_map.get(old_column_id)
+                if new_column is not None:
+                    column_order.column = new_column
+                column_order.save()
+
+            return clone

--- a/flexible_reports/templates/admin/flexible_reports/change_form_with_clone.html
+++ b/flexible_reports/templates/admin/flexible_reports/change_form_with_clone.html
@@ -1,0 +1,17 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+  {{ block.super }}
+  {# Cloning changes the database, so it has to be a POST -- a plain link
+     would let a foreign page create objects through an <img src="...">.
+     The block renders before the main <form> opens, so this one is not
+     nested. #}
+  <li>
+    <form method="post"
+          action="{% url opts|admin_urlname:'clone' original.pk|admin_urlquote %}">
+      {% csrf_token %}
+      <button type="submit" class="button">{% translate "Clone" %}</button>
+    </form>
+  </li>
+{% endblock %}

--- a/test_app/tests/test_adapters.py
+++ b/test_app/tests/test_adapters.py
@@ -1,7 +1,11 @@
 # -*- encoding: utf-8 -*-
+import re
+import threading
+
 import pytest
 from bs4 import BeautifulSoup
 from django.contrib.contenttypes.models import ContentType
+from django.template.base import Template
 from django.template.context import RequestContext
 from model_bakery import baker
 
@@ -14,6 +18,217 @@ from flexible_reports.models.report import (
 from test_app.models import MyTestBar
 
 from ..models import MyTestFoo
+
+
+@pytest.fixture(autouse=True)
+def clear_compiled_template_cache():
+    # A cached Template remembers the engine active when it was compiled, so
+    # the cache must not be carried between tests (override_settings(TEMPLATES)
+    # would otherwise be served templates bound to the previous engine).
+    django_tables2._compiled_template.cache_clear()
+    yield
+    django_tables2._compiled_template.cache_clear()
+
+
+def _build_report(column_labels, column_template="{{ value }}", values=(1, 2, 3)):
+    """Build a one-element report over ``MyTestFoo``.
+
+    Returns a (report, table, columns) tuple.
+    """
+    mtf = ContentType.objects.get_for_model(MyTestFoo)
+
+    for value in values:
+        baker.make(MyTestFoo, i=value)
+
+    r = baker.make(Report, title="Report title")
+    t = baker.make(Table, label="table", base_model=mtf)
+
+    columns = [
+        baker.make(
+            Column,
+            label=label,
+            parent=t,
+            attr_name="i",
+            template=column_template,
+            position=position,
+        )
+        for position, label in enumerate(column_labels)
+    ]
+
+    ds = baker.make(Datasource, base_model=mtf, dsl_query="i > 0")
+    baker.make(
+        ReportElement,
+        title="Report element title",
+        slug="element",
+        table=t,
+        parent=r,
+        datasource=ds,
+        data_from=DATA_FROM_DATASOURCE,
+    )
+
+    r.set_base_queryset(MyTestFoo.objects.all())
+
+    return r, t, columns
+
+
+@pytest.mark.django_db
+def test_label_change_visible_without_restart(rf):
+    # Regression: the table class used to be cached per Table.pk for the
+    # lifetime of the process, so a label edited in the database was invisible
+    # until the process restarted.
+    r, t, columns = _build_report(["Old label"])
+
+    request = rf.get("/")
+
+    first = django_tables2.as_html(r, RequestContext(request, dict(request=request)))
+    assert "Old label" in first
+
+    Column.objects.filter(pk=columns[0].pk).update(label="New label")
+
+    second = django_tables2.as_html(r, RequestContext(request, dict(request=request)))
+    assert "New label" in second
+    assert "Old label" not in second
+
+
+@pytest.mark.django_db
+def test_removed_column_disappears(rf):
+    # Regression: a column removed from the database stayed in the cached
+    # class' ``base_columns`` and kept being rendered.
+    r, t, columns = _build_report(["Keep me", "Delete me"])
+
+    request = rf.get("/")
+
+    first = django_tables2.as_html(r, RequestContext(request, dict(request=request)))
+    assert "Keep me" in first
+    assert "Delete me" in first
+
+    columns[1].delete()
+
+    second = django_tables2.as_html(r, RequestContext(request, dict(request=request)))
+    assert "Keep me" in second
+    assert "Delete me" not in second
+
+
+@pytest.mark.django_db
+def test_template_column_context_is_complete(rf):
+    # The overridden TemplateColumn.render must provide the very same context
+    # as the parent implementation: the page context of the template that
+    # called {% render_table %}, the record, the value and the row counter.
+    r, t, columns = _build_report(
+        ["Cell"],
+        column_template=(
+            "[{{ row_counter }}|{{ record.i }}|{{ value }}|{{ page_variable }}]"
+        ),
+        values=(11, 22, 33),
+    )
+
+    request = rf.get("/")
+    ctx = RequestContext(request, dict(request=request, page_variable="from-page"))
+
+    render_context = django_tables2._report(r, ctx)
+    html = Template(r.template).render(render_context)
+
+    cells = re.findall(r"\[(.*?)\]", html)
+    assert len(cells) == 3
+
+    row_counters = []
+    for cell in cells:
+        row_counter, record_value, value, page_variable = cell.split("|")
+        row_counters.append(row_counter)
+        assert record_value == value
+        assert record_value in ("11", "22", "33")
+        assert page_variable == "from-page"
+
+    # Every row must get its own counter -- proof that ``bound_row`` reaches
+    # ``get_context_data``.
+    assert sorted(row_counters) == ["0", "1", "2"]
+
+    # The cell variables have to be popped from the page context once the cell
+    # has been rendered; ``parent_context.update()`` is used as a context
+    # manager precisely for that.
+    for leaked in ("row_counter", "record", "value", "column", "default"):
+        assert leaked not in render_context
+
+
+@pytest.mark.django_db
+def test_no_template_pinned_to_column(rf):
+    # Columns live in ``Table.base_columns`` and are deep-copied on every table
+    # instantiation. A compiled ``Template`` references the template engine, so
+    # pinning one onto a column would deep-copy the whole engine graph.
+    r, t, columns = _build_report(["Cell"])
+
+    request = rf.get("/")
+    ctx = RequestContext(request, dict(request=request))
+
+    render_context = django_tables2._report(r, ctx)
+    Template(r.template).render(render_context)
+
+    table_instance = render_context["elements"]["element"]["table"]
+
+    column_instances = list(type(table_instance).base_columns.values())
+    column_instances += list(table_instance.base_columns.values())
+    # The columns actually used while rendering are the deep copies held by the
+    # bound columns, so check those as well.
+    column_instances += [bc.column for bc in table_instance.columns.iterall()]
+
+    for column_instance in column_instances:
+        pinned = [
+            name
+            for name, value in vars(column_instance).items()
+            if isinstance(value, Template)
+        ]
+        assert pinned == []
+
+
+@pytest.mark.django_db
+def test_compiled_template_cache_is_used(rf):
+    r, t, columns = _build_report(["Cell"], values=(1, 2, 3))
+
+    request = rf.get("/")
+
+    django_tables2.as_html(r, RequestContext(request, dict(request=request)))
+    hits_after_first = django_tables2._compiled_template.cache_info().hits
+
+    # Three rows, one column: the template is compiled once and reused.
+    assert hits_after_first > 0
+
+    django_tables2.as_html(r, RequestContext(request, dict(request=request)))
+    assert django_tables2._compiled_template.cache_info().hits > hits_after_first
+
+
+@pytest.mark.django_db
+def test_concurrent_render(rf):
+    r, t, columns = _build_report(
+        ["Cell"], column_template="[{{ row_counter }}|{{ value }}]", values=(11, 22, 33)
+    )
+
+    request = rf.get("/")
+
+    # The data is materialized and the table classes are built up front so the
+    # threads only exercise the shared compiled-template path, without touching
+    # the database from a connection that cannot see this test's transaction.
+    object_list = list(MyTestFoo.objects.all().order_by("i"))
+    tables = [django_tables2.table(t, request, object_list) for _ in range(2)]
+
+    results = {}
+    errors = []
+
+    def render(index):
+        try:
+            results[index] = tables[index].as_html(request)
+        except Exception as e:  # pragma: no cover - only on a real failure
+            errors.append(e)
+
+    threads = [threading.Thread(target=render, args=(i,)) for i in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(results) == 2
+    assert "[0|11]" in results[0]
+    assert results[0] == results[1]
 
 
 @pytest.mark.django_db

--- a/test_app/tests/test_admin/test_cloning.py
+++ b/test_app/tests/test_admin/test_cloning.py
@@ -1,0 +1,175 @@
+# -*- encoding: utf-8 -*-
+
+import pytest
+from django.contrib.admin.models import ADDITION, LogEntry
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.urls import resolve, reverse
+from model_bakery import baker
+
+from flexible_reports.models import Report, Table
+from test_app.models import MyTestFoo
+
+
+def _table():
+    return baker.make(
+        Table,
+        label="My table",
+        base_model=ContentType.objects.get_for_model(MyTestFoo),
+    )
+
+
+def _staff_user(django_user_model, model, codenames):
+    """A staff user holding exactly ``codenames`` on ``model``."""
+    user = django_user_model.objects.create_user(
+        username="staff", password="secret", is_staff=True
+    )
+    content_type = ContentType.objects.get_for_model(model)
+    user.user_permissions.set(
+        Permission.objects.filter(content_type=content_type, codename__in=codenames)
+    )
+    return user
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("model_name", ["table", "report"])
+def test_clone_button_visible(admin_client, model_name):
+    if model_name == "table":
+        obj = _table()
+    else:
+        obj = baker.make(Report, title="My report", slug="my-report")
+
+    change_url = reverse("admin:flexible_reports_%s_change" % model_name, args=[obj.pk])
+    clone_url = reverse("admin:flexible_reports_%s_clone" % model_name, args=[obj.pk])
+
+    res = admin_client.get(change_url)
+    assert res.status_code == 200
+
+    content = res.rendered_content
+    start = content.index('action="%s"' % clone_url)
+    form = content[start : content.index("</form>", start)]
+    # The button posts -- a plain link would let a foreign page create objects
+    # through an <img src="...">.
+    assert "csrfmiddlewaretoken" in form
+    # {{ block.super }} keeps the stock tools (History, View on site).
+    assert "historylink" in content
+
+
+@pytest.mark.django_db
+def test_clone_url_not_swallowed_by_catchall(admin_client):
+    # Regression guard: ModelAdmin.get_urls() ends with a backwards-compat
+    # catch-all ``<path:object_id>/`` whose converter matches slashes. If our
+    # route were appended *after* super().get_urls(), ``<pk>/clone/`` would
+    # resolve to that RedirectView instead of our view.
+    obj = _table()
+    url = reverse("admin:flexible_reports_table_clone", args=[obj.pk])
+
+    assert resolve(url).func.__name__ == "clone_view"
+
+    res = admin_client.post(url)
+    assert res.status_code == 302
+    assert "/clone/change/" not in res["Location"]
+    assert Table.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_clone_requires_post(admin_client):
+    obj = _table()
+    url = reverse("admin:flexible_reports_table_clone", args=[obj.pk])
+
+    res = admin_client.get(url)
+    assert res.status_code == 405
+    assert Table.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_clone_anonymous_redirects_to_login(client):
+    # admin_view has to wrap require_POST, not the other way round: an
+    # anonymous GET must be sent to the login page instead of being told 405,
+    # which would leak the existence of the URL.
+    obj = _table()
+    url = reverse("admin:flexible_reports_table_clone", args=[obj.pk])
+
+    res = client.get(url)
+    assert res.status_code == 302
+    assert "/admin/login/" in res["Location"]
+
+
+@pytest.mark.django_db
+def test_clone_requires_add_permission(client, django_user_model):
+    obj = _table()
+    _staff_user(django_user_model, Table, ["view_table", "change_table"])
+    client.login(username="staff", password="secret")
+
+    url = reverse("admin:flexible_reports_table_clone", args=[obj.pk])
+    res = client.post(url)
+    assert res.status_code == 403
+    assert Table.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_clone_requires_view_permission(client, django_user_model):
+    obj = _table()
+    _staff_user(django_user_model, Table, ["add_table"])
+    client.login(username="staff", password="secret")
+
+    url = reverse("admin:flexible_reports_table_clone", args=[obj.pk])
+    res = client.post(url)
+    assert res.status_code == 403
+    assert Table.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_clone_missing_object_404(admin_client):
+    url = reverse("admin:flexible_reports_table_clone", args=[123456])
+    res = admin_client.post(url)
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+def test_clone_redirects_to_clone(admin_client):
+    obj = _table()
+    url = reverse("admin:flexible_reports_table_clone", args=[obj.pk])
+
+    res = admin_client.post(url)
+    assert res.status_code == 302
+
+    clone = Table.objects.exclude(pk=obj.pk).get()
+    assert res["Location"] == reverse(
+        "admin:flexible_reports_table_change", args=[clone.pk]
+    )
+
+
+@pytest.mark.django_db
+def test_clone_redirects_to_changelist_without_change_permission(
+    client, django_user_model
+):
+    # Landing on the clone's change form would be a 403 for this user, so we
+    # fall back to the changelist -- mirrors ModelAdmin._response_post_save.
+    obj = _table()
+    _staff_user(django_user_model, Table, ["add_table", "view_table"])
+    client.login(username="staff", password="secret")
+
+    url = reverse("admin:flexible_reports_table_clone", args=[obj.pk])
+    res = client.post(url)
+    assert res.status_code == 302
+    assert res["Location"] == reverse("admin:flexible_reports_table_changelist")
+    assert Table.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_clone_logs_addition(admin_client):
+    obj = _table()
+    url = reverse("admin:flexible_reports_table_clone", args=[obj.pk])
+
+    admin_client.post(url)
+
+    clone = Table.objects.exclude(pk=obj.pk).get()
+    entry = LogEntry.objects.get(
+        content_type=ContentType.objects.get_for_model(Table),
+        object_id=str(clone.pk),
+        action_flag=ADDITION,
+    )
+    # The message structure matters: it is what makes the history page say
+    # "Added." instead of showing a raw string.
+    assert entry.get_change_message() == "Added."

--- a/test_app/tests/test_models/test_cloning.py
+++ b/test_app/tests/test_models/test_cloning.py
@@ -1,0 +1,257 @@
+# -*- encoding: utf-8 -*-
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from model_bakery import baker
+
+from flexible_reports.models import Column, Datasource, Report, ReportElement, Table
+from flexible_reports.models.report import (
+    DATA_FROM_DATASOURCE,
+    DATA_FROM_EXCEPT_CATCHALL,
+)
+from flexible_reports.models.table import ColumnOrder
+from test_app.models import MyTestFoo
+
+
+@pytest.fixture
+def base_model():
+    return ContentType.objects.get_for_model(MyTestFoo)
+
+
+@pytest.fixture
+def table(base_model):
+    t = baker.make(
+        Table,
+        label="My table",
+        base_model=base_model,
+        group_prefix="pfx",
+    )
+    first = baker.make(
+        Column,
+        parent=t,
+        label="First column",
+        attr_name="i",
+        position=0,
+        template="{{ value }}",
+    )
+    second = baker.make(
+        Column,
+        parent=t,
+        label="Second column",
+        attr_name="i",
+        position=1,
+        template="{{ value }}!",
+    )
+    baker.make(ColumnOrder, table=t, column=second, desc=True, position=0)
+    baker.make(ColumnOrder, table=t, column=first, desc=False, position=1)
+    return t
+
+
+@pytest.fixture
+def report(table, base_model):
+    r = baker.make(Report, title="My report", slug="my-report", template="{{ foo }}")
+    ds = baker.make(Datasource, base_model=base_model, dsl_query="i > 0")
+    baker.make(
+        ReportElement,
+        parent=r,
+        title="First element",
+        slug="first-element",
+        table=table,
+        datasource=ds,
+        data_from=DATA_FROM_DATASOURCE,
+        position=0,
+    )
+    return r
+
+
+@pytest.mark.django_db
+def test_clone_table_copies_columns(table):
+    clone = table.clone()
+
+    assert clone.pk != table.pk
+    assert clone.base_model_id == table.base_model_id
+    assert clone.group_prefix == table.group_prefix
+
+    original_columns = list(Column.objects.filter(parent=table).order_by("position"))
+    cloned_columns = list(Column.objects.filter(parent=clone).order_by("position"))
+
+    assert len(cloned_columns) == len(original_columns) == 2
+
+    for original, cloned in zip(original_columns, cloned_columns):
+        assert cloned.pk != original.pk
+        assert cloned.parent_id == clone.pk
+        assert cloned.label == original.label
+        assert cloned.attr_name == original.attr_name
+        assert cloned.template == original.template
+        assert cloned.position == original.position
+
+
+@pytest.mark.django_db
+def test_clone_table_remaps_column_order(table):
+    clone = table.clone()
+
+    original_orders = list(ColumnOrder.objects.filter(table=table).order_by("position"))
+    cloned_orders = list(ColumnOrder.objects.filter(table=clone).order_by("position"))
+
+    assert len(cloned_orders) == len(original_orders) == 2
+
+    cloned_column_pks = set(
+        Column.objects.filter(parent=clone).values_list("pk", flat=True)
+    )
+
+    for original, cloned in zip(original_orders, cloned_orders):
+        # Both foreign keys have to be repointed at the clone.
+        assert cloned.table_id == clone.pk
+        assert cloned.column_id in cloned_column_pks
+        assert cloned.column_id != original.column_id
+        # ... and the ordering itself has to be preserved.
+        assert cloned.column.label == original.column.label
+        assert cloned.desc == original.desc
+        assert cloned.position == original.position
+
+
+@pytest.mark.django_db
+def test_clone_table_does_not_touch_source(table):
+    # Load the source the way the admin does -- with a prefetched, *cached*
+    # related manager. Nulling PKs on cached instances would corrupt objects
+    # the caller still holds.
+    source = Table.objects.prefetch_related("column_set").get(pk=table.pk)
+    cached_columns = list(source.column_set.all())
+    original_pk = source.pk
+    original_label = source.label
+    original_column_pks = [c.pk for c in cached_columns]
+
+    source.clone()
+
+    assert source.pk == original_pk
+    assert source.label == original_label
+    assert [c.pk for c in cached_columns] == original_column_pks
+    # The cached manager must still hand back exactly the source's columns.
+    assert [c.pk for c in source.column_set.all()] == original_column_pks
+    assert all(c.parent_id == original_pk for c in source.column_set.all())
+
+    # Nothing got moved away from the source in the database either.
+    assert Column.objects.filter(parent=source).count() == 2
+    assert ColumnOrder.objects.filter(table=source).count() == 2
+
+
+@pytest.mark.django_db
+def test_clone_table_is_independent(table):
+    clone = table.clone()
+
+    cloned_column = Column.objects.filter(parent=clone).order_by("position").first()
+    cloned_column.label = "Changed label"
+    cloned_column.attr_name = "id"
+    cloned_column.save()
+
+    original_column = Column.objects.filter(parent=table).order_by("position").first()
+    assert original_column.label == "First column"
+    assert original_column.attr_name == "i"
+
+
+@pytest.mark.django_db
+def test_clone_table_label_is_numbered(table):
+    first = table.clone()
+    assert first.label == "My table (copy)"
+
+    second = table.clone()
+    assert second.label == "My table (copy 2)"
+
+    # A clone of a clone strips the existing suffix instead of nesting it.
+    third = first.clone()
+    assert third.label == "My table (copy 3)"
+
+
+@pytest.mark.django_db
+def test_clone_report_shares_tables(report):
+    clone = report.clone()
+
+    original_element = ReportElement.objects.get(parent=report)
+    cloned_element = ReportElement.objects.get(parent=clone)
+
+    assert cloned_element.pk != original_element.pk
+    # Shallow clone: the very same Table and Datasource rows.
+    assert cloned_element.table_id == original_element.table_id
+    assert cloned_element.datasource_id == original_element.datasource_id
+    assert Table.objects.count() == 1
+    assert Datasource.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_clone_report_copies_elements(report, table):
+    baker.make(
+        ReportElement,
+        parent=report,
+        title="Second element",
+        slug="second-element",
+        table=table,
+        datasource=Datasource.objects.first(),
+        data_from=DATA_FROM_DATASOURCE,
+        position=1,
+    )
+
+    clone = report.clone()
+
+    assert clone.pk != report.pk
+    assert clone.title == "My report (copy)"
+    assert clone.template == report.template
+
+    original_elements = list(
+        ReportElement.objects.filter(parent=report).order_by("position")
+    )
+    cloned_elements = list(
+        ReportElement.objects.filter(parent=clone).order_by("position")
+    )
+
+    assert len(cloned_elements) == len(original_elements) == 2
+    # Element slugs stay unchanged -- the copied report template addresses
+    # them by slug.
+    assert [e.slug for e in cloned_elements] == [e.slug for e in original_elements]
+    assert [e.title for e in cloned_elements] == [e.title for e in original_elements]
+    assert all(e.parent_id == clone.pk for e in cloned_elements)
+
+
+@pytest.mark.django_db
+def test_clone_report_handles_except_catchall(base_model):
+    r = baker.make(Report, title="Catchall report", slug="catchall-report")
+    baker.make(
+        ReportElement,
+        parent=r,
+        title="Catchall element",
+        slug="catchall-element",
+        table=baker.make(Table, label="t", base_model=base_model),
+        datasource=None,
+        base_model=base_model,
+        data_from=DATA_FROM_EXCEPT_CATCHALL,
+    )
+
+    clone = r.clone()
+
+    cloned_element = ReportElement.objects.get(parent=clone)
+    assert cloned_element.datasource_id is None
+    assert cloned_element.base_model_id == base_model.pk
+    assert cloned_element.data_from == DATA_FROM_EXCEPT_CATCHALL
+    cloned_element.clean()
+
+
+@pytest.mark.django_db
+def test_clone_report_unique_slug():
+    max_length = Report._meta.get_field("slug").max_length
+    assert max_length == 50
+
+    slug = "a" * 50
+    r = baker.make(Report, title="Long slug report", slug=slug)
+
+    clone = r.clone()
+
+    assert clone.slug != r.slug
+    assert len(clone.slug) <= max_length
+    # The stem gets truncated, never the suffix.
+    assert clone.slug.endswith("-copy")
+
+    second = r.clone()
+    assert second.slug != clone.slug
+    assert len(second.slug) <= max_length
+    assert second.slug.endswith("-copy-2")
+
+    assert Report.objects.filter(slug=r.slug).count() == 1


### PR DESCRIPTION
Three changes, requested together.

## 1 & 2. Cloning tables and reports

A **Clone** button on the change form of `Table` and `Report`.

- **`Table.clone()`** copies the table, its columns, and its sort order.
- **`Report.clone()`** is shallow: copied elements point at the *same* `Table` and `Datasource` rows. Deep-copying would fill the admin with near-identical tables; whoever wants an independent table clones it separately and repoints the element.
- Clone names get a translatable `(copy)` suffix (`kopia` in the Polish `.po`), numbered on repeat. Cloning a clone gives `X (copy 2)`, not `X (copy) (copy)`.
- Neither method mutates the source or anything reachable from it.

Both are usable from a shell/script, not just the admin — the logic lives on the models.

## 3. The label change that needed a restart — yes, it was our fault

`_table_cache` kept an `AdHocTable` class per `Table.pk` for the **lifetime of the process, with no invalidation** (added in 40d9da4 "Speedups"). Editing a column label — or deleting a column — stayed invisible until Django restarted. With several workers it was worse: the edit landed in one process while the others kept serving stale headers, so the page alternated between old and new depending on who answered.

### Why the cache was deleted rather than invalidated

Signal-based invalidation only fixes the worker that handled the edit. A versioned key (`Table.modified` + migration + signals) would work across processes — so I measured what it was defending first:

| | 20 rows | 100 | 500 | 1000 |
|---|---|---|---|---|
| Cached class build (what the cache saves) | 0.48 ms | 0.46 ms | 0.46 ms | 0.45 ms |
| Full table render | 6.4 ms | 30.5 ms | 172.7 ms | 312.6 ms |
| **Cache's share of a render** | 7.4% | 1.5% | 0.27% | 0.14% |

The saving is flat; render cost grows with rows. Two structural reasons it could never be worth more:

- `Table.__init__` deep-copies `base_columns` on **every** instantiation regardless (`tables.py:318`).
- `TemplateColumn.render()` recompiles its template for **every cell** (`templatecolumn.py:116`) — 4000 compilations for a 500×8 table.

So a migration and two signals to save 0.46 ms was not the trade to make.

### What replaced it

The per-cell compilation — the actual hot spot — is now cached, keyed by **template source**, so it needs no invalidation: editing a template yields a different key. Measured on the final code, 500×8:

```
Before (class cache + per-cell compile):  151.4 ms
After  (no class cache + template cache): 121.4 ms   -> 1.25x faster
```

**Renders faster than before despite the cache being gone**, with labels always fresh in every worker.

The compiled `Template` is deliberately never pinned to a column instance: columns are deep-copied on every table instantiation and a `Template` references the engine, so pinning it would drag the whole engine graph through `deepcopy` — a regression, not a speedup. A test enforces this.

## Notes for review

- The spec (`docs/superpowers/specs/`) went through an adversarial review that caught three blockers, all verified against the installed Django 6.0.7 and each now covered by a test: admin URL ordering vs. the `<path:object_id>/` catch-all, `require_POST` placement (500 vs 405), and `clone()` corrupting `prefetch_related`-cached children.
- **Unverified:** the button against `grappelli`, which ships its own `admin/change_form.html`. Noted in `HISTORY.rst`; worth a manual check before release.
- Unrelated pre-existing bug spotted, not fixed here: `docker-compose.yml` lacks `POSTGRES_HOST_AUTH_METHOD: trust`, so the db container will not start with a modern postgres image (CI sets it, compose does not).

## Tests

57 → 83. Includes regression tests for the stale label and the removed column, both confirmed failing before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lcd5LHZzVDuTc3ZktAPoZL