### PR TITLE
Release 0.4.0 via PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+# Publishing is driven by tags: `bump-my-version bump minor` writes the new
+# version, commits and tags it, and pushing that tag runs this workflow.
+#
+# Authentication is PyPI Trusted Publishing (OIDC) -- there is no API token in
+# this repository and none needs to exist. PyPI is configured to trust exactly
+# this repository, this workflow file and the `pypi` environment below; change
+# any of the three and PyPI will refuse the upload.
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      # A tag and the version inside the package can drift apart -- someone
+      # tags v0.4.0 by hand while pyproject.toml still says 0.3.2, and the
+      # upload succeeds under the wrong version. Fail loudly instead.
+      - name: Check the tag matches the packaged version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(uv run --no-project python -c "
+          import tomllib, pathlib
+          print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])
+          ")
+          echo "tag=$tag packaged=$pkg"
+          test "$tag" = "$pkg" || {
+            echo "::error::tag $GITHUB_REF_NAME does not match pyproject version $pkg"
+            exit 1
+          }
+
+      - name: Build
+        run: uv build
+
+      - name: Check metadata renders on PyPI
+        run: uvx twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    # Named environment so the trusted-publisher binding on PyPI can be scoped
+    # to it, and so a protection rule can gate uploads if you ever want one.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-flexible-reports
+
+    permissions:
+      id-token: write # required for Trusted Publishing; nothing else needs it
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create the GitHub release
+    needs: pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # required to create the release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create release with the changelog section for this version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          # Pull just this version's section out of HISTORY.md.
+          awk -v v="$version" '
+            $0 ~ "^## " v " " {found=1; next}
+            found && /^## / {exit}
+            found {print}
+          ' HISTORY.md > notes.md
+          test -s notes.md || echo "See HISTORY.md." > notes.md
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file notes.md

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 0.4.0 (unreleased)
+## 0.4.0 (2026-07-22)
 
 * **Backwards incompatible:** the minimum supported Django is now 5.2 LTS.
   Tested against Django 5.2 and 6.0.


### PR DESCRIPTION
Prepares the 0.4.0 release. Everything merged since 0.3.2 is currently invisible to users — PyPI still serves the June build, with the un-invalidated table cache and no cloning.

## Publishing

Pushing a `v*` tag builds, publishes to PyPI, and opens a GitHub release with that version's `HISTORY.md` section attached.

Authentication is **Trusted Publishing (OIDC)** — no API token in the repo, in CI secrets, or on anyone's disk. `id-token: write` is granted only to the publishing job; the top-level default stays `contents: read`.

The build job **refuses to publish when the tag and the packaged version disagree**. Tagging `v0.4.0` while `pyproject.toml` still said `0.3.2` would otherwise upload cheerfully under the wrong version — the same "succeeds while doing the wrong thing" shape as the CI matrix and `make test` fixed earlier in this series.

No `${{ }}` interpolation inside any `run:` block; tag names reach the shell as quoted environment variables.

## ⚠️ One-time setup required before the tag is pushed

The trusted publisher must exist on PyPI **first**, or the upload fails. On https://pypi.org/manage/project/django-flexible-reports/settings/publishing/ add a GitHub publisher with exactly:

| Field | Value |
|---|---|
| Owner | `mpasternak` |
| Repository name | `django-flexible-reports` |
| Workflow name | `release.yml` |
| Environment name | `pypi` |

All four must match or PyPI rejects the upload — that strictness is the point.

## Then

Once this is merged and PyPI is configured, `bump-my-version bump minor` takes 0.3.2 → 0.4.0 across `pyproject.toml` and `flexible_reports/__init__.py`, commits and tags it; pushing the tag does the rest.

## Verification

```
YAML parses; jobs: build, pypi, github-release; trigger: tags v*
pypi job permissions: {id-token: write}; environment: pypi
${{ }} inside run: blocks: 0
version read from pyproject: 0.3.2  (tag guard works against a real value)
HISTORY.md section extraction for 0.4.0: 46 lines
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lcd5LHZzVDuTc3ZktAPoZL