### PR TITLE
Audit follow-ups: Python 3.14, PyPI metadata, CI hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Set up Python
         run: uv python install 3.13

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [master]
 
+# The default GITHUB_TOKEN is broader than anything here needs; tests only
+# ever read the checkout.
+permissions:
+  contents: read
+
 env:
   POSTGRES_HOST: localhost
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -16,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         django-version: ["5.2", "6.0"]
         exclude:
           # Django 6.0 requires Python 3.12+
@@ -42,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -86,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Set up Python
         run: uv python install 3.13

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,6 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.22
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # History
 
+## Unreleased
+
+* Python 3.14 is supported and tested, against both Django 5.2 LTS and 6.0.
+
+* PyPI metadata is fuller: real keywords instead of just the package name, and
+  links to the documentation, repository, issue tracker and changelog rather
+  than the homepage alone. `Development Status` moves from `3 - Alpha` to
+  `5 - Production/Stable`.
+
 ## 0.4.0 (2026-07-22)
 
 * **Backwards incompatible:** the minimum supported Django is now 5.2 LTS.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Django Flexible Reports
 
-[![PyPI](https://badge.fury.io/py/django-flexible-reports.svg)](https://badge.fury.io/py/django-flexible-reports)
+[![PyPI Version](https://img.shields.io/pypi/v/django-flexible-reports.svg)](https://pypi.org/project/django-flexible-reports/)
+[![Python Version](https://img.shields.io/pypi/pyversions/django-flexible-reports.svg)](https://pypi.org/project/django-flexible-reports/)
 [![Tests](https://github.com/mpasternak/django-flexible-reports/actions/workflows/tests.yml/badge.svg)](https://github.com/mpasternak/django-flexible-reports/actions/workflows/tests.yml)
 [![Docs](https://github.com/mpasternak/django-flexible-reports/actions/workflows/docs.yml/badge.svg)](https://github.com/mpasternak/django-flexible-reports/actions/workflows/docs.yml)
+[![License](https://img.shields.io/pypi/l/django-flexible-reports.svg)](LICENSE)
 
 A framework for **database-defined reports** in Django.
 
@@ -22,10 +24,10 @@ so you get sortable headers, footers/totals and export for free.
 
 ## Supported Versions
 
-|                | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 |
-|----------------|:-----------:|:-----------:|:-----------:|:-----------:|
-| Django 5.2 LTS |      ✔      |      ✔      |      ✔      |      ✔      |
-| Django 6.0     |      —      |      —      |      ✔      |      ✔      |
+|                | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 | Python 3.14 |
+|----------------|:-----------:|:-----------:|:-----------:|:-----------:|:-----------:|
+| Django 5.2 LTS |      ✔      |      ✔      |      ✔      |      ✔      |      ✔      |
+| Django 6.0     |      —      |      —      |      ✔      |      ✔      |      ✔      |
 
 Django 6.0 requires Python 3.12+. Django 4.2, 5.0 and 5.1 are no longer
 supported or tested — the floor is Django 5.2 LTS.
@@ -83,7 +85,13 @@ The full documentation is at
 
 ## Quickstart
 
-Install Django Flexible Reports:
+Install Django Flexible Reports, with [uv](https://docs.astral.sh/uv/):
+
+```
+uv add django-flexible-reports
+```
+
+or with pip:
 
 ```
 pip install django-flexible-reports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,17 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 authors = [{name = "Michał Pasternak", email = "michal.dtz@gmail.com"}]
-keywords = ["django-flexible-reports"]
+keywords = [
+    "django",
+    "reports",
+    "reporting",
+    "django-tables2",
+    "admin",
+    "djangoql",
+    "export",
+]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
@@ -22,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "Django>=5.2",
@@ -59,6 +68,10 @@ test = [
 
 [project.urls]
 Homepage = "https://github.com/mpasternak/django-flexible-reports"
+Documentation = "https://mpasternak.github.io/django-flexible-reports/"
+Repository = "https://github.com/mpasternak/django-flexible-reports"
+Issues = "https://github.com/mpasternak/django-flexible-reports/issues"
+Changelog = "https://github.com/mpasternak/django-flexible-reports/blob/master/HISTORY.md"
 
 [tool.setuptools.packages.find]
 include = ["flexible_reports*"]


### PR DESCRIPTION
Ran the OSS-publication audit and a README review over the repo. **Security came back completely clean** — no secrets, no tokens, no private keys, no tracked `.env`/IDE configs, nothing in git history, and the only email anywhere is your own in `AUTHORS`/`pyproject`/`.po`. Zero FAIL findings; everything here is WARN-level polish.

## Python 3.14 was already supported — nobody had said so

The canonical Django × Python matrix says 5.2 LTS and 6.0 both support 3.14. We tested neither. So I checked before claiming anything:

| | result |
|---|---|
| Python 3.14 + Django 6.0 | 83 passed |
| Python 3.14 + Django 5.2 | 83 passed |
| Python 3.14 + grappelli | 4 passed |

Now in the CI matrix (8 legs), the classifiers, and the README table.

One honest wrinkle: the `pyversions` badge reads *published* metadata, so it keeps showing up to 3.13 until the next release. The package already runs on 3.14 — `requires-python` has no upper bound — the classifier just hasn't shipped yet.

## PyPI metadata was thin

- `keywords = ["django-flexible-reports"]` — the package name and nothing else, which makes it unfindable by PyPI search. Now: django, reports, reporting, django-tables2, admin, djangoql, export.
- `[project.urls]` had only `Homepage`, so the PyPI sidebar hid the documentation site we had just stood up. Added Documentation, Repository, Issues, Changelog.
- `Development Status :: 3 - Alpha` on a package that has been on PyPI since 2017 → `5 - Production/Stable`.

## CI hardening

- **`tests.yml` had no `permissions:` block** — it ran with the default, broader `GITHUB_TOKEN`. `docs.yml` and `release.yml` already scoped theirs. Now `contents: read`.
- **`astral-sh/setup-uv` pinned to a commit SHA** (`d4b2f3b` = v5.4.2). It is the only third-party action here; after the tj-actions compromise, tag pins on third-party actions are a supply-chain risk for public repos.

## README

Added `uv add` alongside `pip install` — the repo uses uv everywhere else, so showing only pip was inconsistent. Added the Python-version and license badges, and moved the PyPI badge off `badge.fury.io` so all five come from shields.io. All badges verified 200.

The pre-commit `ruff` hook id was the deprecated alias — pre-commit itself printed "ruff (legacy alias)" on every run. It is `ruff-check` now.

## Left alone, deliberately

Three bits of legacy that are cosmetic and outside this change's scope:

- `from __future__ import ...` in 15 files (12 migrations plus `manage.py`, `tests/settings.py`, `tests/urls.py`)
- `tests/urls.py` has a dead `try: re_path / except ImportError: from django.conf.urls import url` shim — `django.conf.urls.url` was removed in Django 4.0, so the `except` branch is unreachable
- `tests/settings.py` uses the Django 1.9-era `postgresql_psycopg2` engine alias

Happy to sweep those separately.

## Verification

```
pytest                  83 passed, 1 skipped
ruff check / format     clean
pre-commit --all-files  7/7 Passed
uv build + twine check  both artifacts PASSED
badges                  5/5 -> 200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lcd5LHZzVDuTc3ZktAPoZL