### PR TITLE
Add Django 6.1 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,13 +22,18 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["5.2", "6.0"]
+        django-version: ["5.2", "6.0", "6.1"]
         exclude:
           # Django 6.0 requires Python 3.12+
           - python-version: "3.10"
             django-version: "6.0"
           - python-version: "3.11"
             django-version: "6.0"
+          # Django 6.1 requires Python 3.12+
+          - python-version: "3.10"
+            django-version: "6.1"
+          - python-version: "3.11"
+            django-version: "6.1"
 
     services:
       postgres:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,12 +164,13 @@ Documentation dependencies live in `docs/requirements.txt`, not in
 Every pull request runs
 [`.github/workflows/tests.yml`](https://github.com/mpasternak/django-flexible-reports/blob/master/.github/workflows/tests.yml), which is:
 
-|                | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 |
-|----------------|:-----------:|:-----------:|:-----------:|:-----------:|
-| Django 5.2 LTS |      ✔      |      ✔      |      ✔      |      ✔      |
-| Django 6.0     |      —      |      —      |      ✔      |      ✔      |
+|                | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 | Python 3.14 |
+|----------------|:-----------:|:-----------:|:-----------:|:-----------:|:-----------:|
+| Django 5.2 LTS |      ✔      |      ✔      |      ✔      |      ✔      |      ✔      |
+| Django 6.0     |      —      |      —      |      ✔      |      ✔      |      ✔      |
+| Django 6.1     |      —      |      —      |      ✔      |      ✔      |      ✔      |
 
-Django 6.0 needs Python 3.12+, so those two legs are excluded. Each leg runs
+Django 6.0 and 6.1 need Python 3.12+, so those legs are excluded. Each leg runs
 the suite against a PostgreSQL service container, then the grappelli test
 separately. A `lint` job runs `ruff check` and `ruff format --check`.
 
@@ -185,9 +186,9 @@ with `--strict` on every pull request, and deploys to GitHub Pages only from
     it.
 3.  **Add a `HISTORY.md` entry** under the topmost *(unreleased)* heading,
     written for someone upgrading rather than for someone reading the diff.
-4.  **Keep the matrix green.** The change has to work on Python 3.10–3.13 with
-    Django 5.2, and on Python 3.12–3.13 with Django 6.0. If you cannot run all
-    of them locally, push the branch and let GitHub Actions tell you.
+4.  **Keep the matrix green.** The change has to work on Python 3.10–3.14 with
+    Django 5.2, and on Python 3.12–3.14 with Django 6.0 and 6.1. If you cannot
+    run all of them locally, push the branch and let GitHub Actions tell you.
 5.  **New user-facing strings go through `gettext`.** The package is
     translated (`flexible_reports/locale/`, currently Polish).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,18 @@
 # History
 
+## (unreleased)
+
+* Added support for Django 6.1. It joins 5.2 LTS and 6.0 in the tested matrix,
+  on Python 3.12–3.14 (Django 6.1 requires Python 3.12+).
+
+* Fixed validation of a `Column` whose *Attribute name* walks a relation in dot
+  notation (`parent.title`) under Django 6.1. Resolving the far end of the
+  relation went through the descriptor's `get_queryset()`, which in Django 6.1
+  takes a mandatory `instance` argument and so cannot be called off the model
+  class any more; every such column was rejected as invalid. The related model
+  now comes from the relation metadata, which reads the same on 5.2, 6.0 and
+  6.1.
+
 ## 0.4.1 (2026-07-23)
 
 * Python 3.14 is supported and tested, against both Django 5.2 LTS and 6.0.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ so you get sortable headers, footers/totals and export for free.
 |----------------|:-----------:|:-----------:|:-----------:|:-----------:|:-----------:|
 | Django 5.2 LTS |      ✔      |      ✔      |      ✔      |      ✔      |      ✔      |
 | Django 6.0     |      —      |      —      |      ✔      |      ✔      |      ✔      |
+| Django 6.1     |      —      |      —      |      ✔      |      ✔      |      ✔      |
 
-Django 6.0 requires Python 3.12+. Django 4.2, 5.0 and 5.1 are no longer
+Django 6.0 and 6.1 require Python 3.12+. Django 4.2, 5.0 and 5.1 are no longer
 supported or tested — the floor is Django 5.2 LTS.
 
 ## Documentation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,8 +4,8 @@
 
 |          |                                            |
 |----------|--------------------------------------------|
-| Python   | 3.10 -- 3.13                               |
-| Django   | 5.2 LTS or 6.0 (6.0 needs Python 3.12+)    |
+| Python   | 3.10 -- 3.14                               |
+| Django   | 5.2 LTS, 6.0 or 6.1 (6.x needs Python 3.12+) |
 | Database | anything Django supports                   |
 
 The following are installed automatically as dependencies:

--- a/flexible_reports/models/column.py
+++ b/flexible_reports/models/column.py
@@ -6,6 +6,37 @@ from django.utils.translation import gettext_lazy as _
 from .behaviors import Labelled, Orderable
 
 
+def _related_model(descriptor):
+    """Model that a related-object descriptor on a model *class* points at.
+
+    ``Column.clean()`` walks a dotted ``attr_name`` from one model class to the
+    next, so it needs the far end of each relation with no instance to hand.
+    The way this used to be obtained -- ``descriptor.get_queryset().model`` --
+    stopped working in Django 6.1, where ``get_queryset()`` grew a mandatory
+    ``instance`` keyword argument and so can no longer be called off the class.
+    The relation metadata holds the same answer and reads the same on Django
+    5.2, 6.0 and 6.1.
+
+    Returns ``None`` for anything that is not a relation to follow, in which
+    case the caller keeps the attribute itself.
+    """
+    # Reverse one-to-one: ``related`` is the OneToOneRel, and its
+    # ``related_model`` is the model declaring the field, i.e. where the
+    # accessor lands.
+    related = getattr(descriptor, "related", None)
+    if related is not None:
+        return getattr(related, "related_model", None)
+
+    # Reverse FK and many-to-many descriptors carry a ``field`` too, but it
+    # points back at the model we came from rather than at the far end; only
+    # they have ``rel``, which is what tells them apart from the forward ones.
+    if hasattr(descriptor, "rel"):
+        return None
+
+    # Forward foreign key / one-to-one.
+    return getattr(getattr(descriptor, "field", None), "related_model", None)
+
+
 class Column(Labelled, Orderable):
     parent = models.ForeignKey("flexible_reports.Table", on_delete=models.CASCADE)
 
@@ -119,8 +150,9 @@ class Column(Labelled, Orderable):
                 try:
                     current_model = getattr(current_model, attr_name)
 
-                    if hasattr(current_model, "get_queryset"):
-                        current_model = current_model.get_queryset().model
+                    related_model = _related_model(current_model)
+                    if related_model is not None:
+                        current_model = related_model
 
                 except Exception as e:
                     raise ValidationError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Django 6.1 was released on 2026-08-05. This adds it as a tested target alongside Django 5.2 LTS and 6.0.

## Changed

- **`.github/workflows/tests.yml`** — `"6.1"` added to the `django-version` matrix, plus `exclude:` entries for `3.10 × 6.1` and `3.11 × 6.1`, mirroring the ones already there for 6.0. **Django 6.1 requires Python 3.12+**, so those two legs cannot exist. The install line (`Django>=${{ matrix.django-version }},<${{ matrix.django-version }}.99`) resolves to `>=6.1,<6.1.99` unchanged, and the guard step that asserts the pinned Django is the one under test needed no change.
- **`pyproject.toml`** — added the `Framework :: Django :: 6.1` classifier. The `Django>=5.2` floor is untouched and there is no upper pin to relax.
- **`README.md`, `CONTRIBUTING.md`, `docs/installation.md`** — supported-version tables gain a Django 6.1 row. `CONTRIBUTING.md` also gains the Python 3.14 column its table was missing and the pull-request checklist now names the real matrix.
- **`HISTORY.md`** — an *(unreleased)* entry.
- **`flexible_reports/models/column.py`** — the one real code fix, below.

## The Django 6.1 incompatibility

`Column.clean()` validates a dotted *Attribute name* (`parent.i`) by walking it across model classes. To step from one model to the next it called the related-field descriptor's `get_queryset()` and took `.model` off the result. In Django 6.1 `ForwardManyToOneDescriptor.get_queryset()` is `def get_queryset(self, *, instance)` — a mandatory keyword argument — so it can no longer be called off the model class at all, and `test_column_foreign` failed with:

```
ForwardManyToOneDescriptor.get_queryset() missing 1 required keyword-only argument: 'instance'
```

In practice that meant **every column whose attribute name crosses a relation was rejected as invalid** under Django 6.1.

The target model now comes from the relation metadata (`descriptor.field.related_model` for forward FK/O2O, `descriptor.related.related_model` for reverse O2O), which reads the same on 5.2, 6.0 and 6.1 and needs no instance. Reverse-FK and many-to-many descriptors are deliberately still not followed, exactly as before — they never had `get_queryset()`.

The existing `test_column_foreign` is the regression test: it fails on 6.1 without this change and passes with it.

## Verification

Full suite run locally against a PostgreSQL 16 container, on all three Django versions, plus the separate grappelli leg and ruff:

| Django | result |
|--------|--------|
| 5.2.17 | 83 passed, 1 skipped |
| 6.0.8  | 83 passed, 1 skipped |
| 6.1    | 83 passed, 1 skipped (+ grappelli leg 4 passed) |

## Note, not fixed here

Under 6.x the suite emits `RemovedInDjango70Warning: Calling select_related() with no arguments is deprecated` from `flexible_reports/adapters/django_tables2.py:171` and `:227`. Warnings only — nothing fails, and 7.0 is a separate piece of work — so it is left alone rather than folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)