### PR TITLE
feat: Report.set_order_by() — sortowanie raportu wybierane w czasie renderu

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,15 @@
 # History
 
+## (unreleased)
+
+* Added `Report.set_order_by(*fields)`, a third render-time setter alongside
+  `set_base_queryset()` and `set_context()`. It overrides the ordering stored
+  on every table of the report for one render, and takes ORM field names
+  rather than the column labels `ColumnOrder` uses — so a report can be sorted
+  by a field that no column displays, which the stored ordering cannot
+  express. `ColumnOrder` is left untouched and keeps serving as the default;
+  calling the setter with no arguments falls back to it.
+
 ## 0.4.2 (2026-08-07)
 
 * Added support for Django 6.1. It joins 5.2 LTS and 6.0 in the tested matrix,

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -136,7 +136,7 @@ being edited.
 | `slug` | How your view looks the report up. |
 | `template` | Django template source for the report's layout. Defaults to the contents of `flexible_reports/templates/flexible_reports/report.html` and is validated on save (it has to compile). |
 
-Two setters have to be called before rendering (see
+Three setters are available before rendering (see
 [Rendering reports](rendering.md)):
 
 `set_base_queryset(queryset)`
@@ -146,8 +146,16 @@ Two setters have to be called before rendering (see
 `set_context(context)`
 :   Optional. A dict used to render parametrised queries.
 
-Both store their value on the in-memory instance only; nothing is written to
-the database.
+`set_order_by(*fields)`
+:   Optional. Overrides the ordering of every table in the report for this
+    render. Takes ORM field names as `QuerySet.order_by()` does (`"-year"`,
+    `"author__surname"`), *not* the column labels
+    [`ColumnOrder`](#columnorder) uses — so you can sort by a field no column
+    displays. Without it, each table keeps its stored `ColumnOrder`; calling it
+    with no arguments restores that fallback.
+
+All three store their value on the in-memory instance only; nothing is written
+to the database.
 
 ## ReportElement
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -34,7 +34,25 @@ def library_report(request):
     [Query languages](queries.md). Defaults to `None`, which the backends
     treat as an empty context.
 
-Both setters only touch the in-memory instance; nothing is saved.
+`set_order_by(*fields)`
+:   Optional. Overrides the ordering of every table in the report for this
+    render:
+
+    ```python
+    report.set_order_by("author__surname", "-year")
+    ```
+
+    The arguments are ORM field names, exactly as `QuerySet.order_by()` takes
+    them -- **not** the column labels that a table's stored `ColumnOrder`
+    uses. That difference is the point: a table can only be ordered by columns
+    it actually has, so `ColumnOrder` cannot sort by a field the report does
+    not display. This setter can.
+
+    Without it, each table keeps the ordering stored in its `ColumnOrder`.
+    Calling it with no arguments restores that fallback.
+
+None of the setters touch anything but the in-memory instance; nothing is
+saved.
 
 ## The template tags
 

--- a/flexible_reports/adapters/django_tables2.py
+++ b/flexible_reports/adapters/django_tables2.py
@@ -161,16 +161,25 @@ def column(column):
     return (column.label, klass)
 
 
-def _table(table):
+def _table(table, ordering_overridden=False):
     # The class is rebuilt on every call. It used to be cached per ``Table.pk``
     # for the lifetime of the process, which made label changes and removed
     # columns invisible until a restart. The cache saved ~0.5 ms per render,
     # far less than caching the compiled column templates does.
+    #
+    # ``ordering_overridden`` means the caller already ordered the queryset via
+    # ``Report.set_order_by``. The table's own ``ColumnOrder`` must then be
+    # dropped rather than merely ignored: django-tables2 applies
+    # ``Meta.order_by`` to the data unconditionally, so leaving it in place
+    # would re-sort the rows and undo the override. With an empty ordering it
+    # skips the queryset entirely (``if accessors:`` in its ``data.py``) and
+    # the caller's ``order_by`` survives.
     order_by = []
-    for column_order in (
-        table.columnorder_set.all().select_related().order_by("position")
-    ):
-        order_by.append(column_order.get())
+    if not ordering_overridden:
+        for column_order in (
+            table.columnorder_set.all().select_related().order_by("position")
+        ):
+            order_by.append(column_order.get())
     table.order_by = order_by
 
     class AdHocTable(Table):
@@ -188,8 +197,8 @@ def _table(table):
     return AdHocTable
 
 
-def table(table, request, object_list):
-    return _table(table)(data=object_list, request=request)
+def table(table, request, object_list, ordering_overridden=False):
+    return _table(table, ordering_overridden)(data=object_list, request=request)
 
 
 def _report(report, parent_context):
@@ -221,6 +230,8 @@ def _report(report, parent_context):
         }
     )
 
+    order_by = report.order_by
+
     reportelements_set = (
         report.reportelement_set.all()
         .prefetch_related("datasource", "datasource__base_model", "table")
@@ -243,10 +254,21 @@ def _report(report, parent_context):
             if datasource.distinct:
                 object_list = object_list.distinct()
 
+            # Ordering is applied here, after the queryset has been handed to
+            # ``catchall``: those copies get OR-ed together further down, and an
+            # ORDER BY on the operands only muddies that combination.
+            if order_by:
+                object_list = object_list.order_by(*order_by)
+
             table_dict = {
                 "title": elem.title,
                 "object_list": object_list,
-                "table": table(elem.table, parent_context["request"], object_list),
+                "table": table(
+                    elem.table,
+                    parent_context["request"],
+                    object_list,
+                    ordering_overridden=bool(order_by),
+                ),
             }
 
         else:
@@ -290,8 +312,15 @@ def _report(report, parent_context):
         key = "%s_%s" % (base_model.app_label, base_model.model)
 
         object_list = render_context["except_catchall"][key]
+        if order_by:
+            object_list = object_list.order_by(*order_by)
         elem["object_list"] = object_list
-        elem["table"] = table(elem["table"], parent_context["request"], object_list)
+        elem["table"] = table(
+            elem["table"],
+            parent_context["request"],
+            object_list,
+            ordering_overridden=bool(order_by),
+        )
 
     return render_context
 

--- a/flexible_reports/models/report.py
+++ b/flexible_reports/models/report.py
@@ -125,6 +125,7 @@ class Report(Titled):
 
     _base_queryset = None
     _context = None
+    _order_by = None
 
     @property
     def base_queryset(self):
@@ -139,6 +140,14 @@ class Report(Titled):
     def context(self):
         return self._context
 
+    @property
+    def order_by(self):
+        """Model field names overriding every table's own ``ColumnOrder``.
+
+        Empty unless :meth:`set_order_by` was called for this render.
+        """
+        return self._order_by
+
     class Meta:
         verbose_name_plural = _("Reports")
         verbose_name = _("Report")
@@ -148,6 +157,20 @@ class Report(Titled):
 
     def set_context(self, context):
         self._context = context
+
+    def set_order_by(self, *fields):
+        """Override the stored ordering of every table in this report.
+
+        ``fields`` are ORM field names as ``QuerySet.order_by`` takes them
+        (``"-rok"``, ``"autor__nazwisko"``), NOT the column labels that
+        ``ColumnOrder`` uses. That is the point of this hook: it can sort by a
+        field no column displays, which ``ColumnOrder`` cannot -- django-tables2
+        only orders by columns that exist on the table.
+
+        The stored ``ColumnOrder`` stays untouched and keeps serving as the
+        default; call this with no arguments to fall back to it.
+        """
+        self._order_by = fields
 
     def clone(self):
         """Copy this report together with its elements.

--- a/test_app/tests/test_adapters.py
+++ b/test_app/tests/test_adapters.py
@@ -458,9 +458,9 @@ def test_except_catchall_rendered_into_element_object_list(rf):
     assert object_list[0].i == 3
 
 
-def _rendered_cells(report, rf):
+def _rendered_cells(report, rf, **query):
     """Cell texts of the report's single table, in rendered top-to-bottom order."""
-    request = rf.get("/")
+    request = rf.get("/", data=query or None)
     html = django_tables2.as_html(
         report, RequestContext(request, dict(request=request))
     )
@@ -534,3 +534,33 @@ def test_set_order_by_with_no_fields_falls_back_to_column_order(rf):
 
     r.set_order_by()
     assert _rendered_cells(r, rf) == ["3", "2", "1"]
+
+
+@pytest.mark.django_db
+def test_column_header_link_sorts_the_table(rf):
+    # The tables render their headers as "?sort=<label>" links, and the whole
+    # Table.sort_option / group_prefix machinery exists to namespace exactly
+    # that parameter -- but nothing ever read it back, so clicking a header
+    # changed the URL and left the rows where they were.
+    r, t, columns = _build_report(["Value"], values=(3, 1, 2))
+    baker.make(ColumnOrder, table=t, column=columns[0], desc=False, position=0)
+
+    assert _rendered_cells(r, rf) == ["1", "2", "3"]
+
+    assert _rendered_cells(r, rf, sort="-Value") == ["3", "2", "1"]
+
+
+@pytest.mark.django_db
+def test_column_header_link_wins_over_set_order_by(rf):
+    # Table.__init__ runs RequestConfig when it gets a request, so a header
+    # click lands after the caller's override. That precedence is the right way
+    # round -- an explicit click is more specific than a default chosen for the
+    # user -- but it only holds because set_order_by sorts the queryset instead
+    # of filling Meta.order_by, so pin it.
+    r, t, columns = _build_report(["Value"], values=(3, 1, 2))
+    baker.make(ColumnOrder, table=t, column=columns[0], desc=False, position=0)
+
+    r.set_order_by("-i")
+    assert _rendered_cells(r, rf) == ["3", "2", "1"]
+
+    assert _rendered_cells(r, rf, sort="Value") == ["1", "2", "3"]

--- a/test_app/tests/test_adapters.py
+++ b/test_app/tests/test_adapters.py
@@ -14,6 +14,7 @@ from flexible_reports.models.report import (
     DATA_FROM_DATASOURCE,
     DATA_FROM_EXCEPT_CATCHALL,
 )
+from flexible_reports.models.table import ColumnOrder
 from test_app.models import MyTestBar
 
 from ..models import MyTestFoo
@@ -455,3 +456,81 @@ def test_except_catchall_rendered_into_element_object_list(rf):
     object_list = res["elements"][ec_elem.slug]["object_list"]
     assert object_list.count() == 1
     assert object_list[0].i == 3
+
+
+def _rendered_cells(report, rf):
+    """Cell texts of the report's single table, in rendered top-to-bottom order."""
+    request = rf.get("/")
+    html = django_tables2.as_html(
+        report, RequestContext(request, dict(request=request))
+    )
+    bs = BeautifulSoup(html, "html.parser")
+    return [td.text.strip() for td in bs.table.tbody.find_all("td")]
+
+
+@pytest.mark.django_db
+def test_set_order_by_overrides_column_order(rf):
+    # The table's own ColumnOrder is the *default* ordering; a caller that
+    # knows better (a view offering the user a choice of sort) overrides it
+    # for one render without touching the stored definition.
+    r, t, columns = _build_report(["Value"], values=(3, 1, 2))
+    baker.make(ColumnOrder, table=t, column=columns[0], desc=False, position=0)
+
+    assert _rendered_cells(r, rf) == ["1", "2", "3"]
+
+    r.set_order_by("-i")
+
+    assert _rendered_cells(r, rf) == ["3", "2", "1"]
+
+
+@pytest.mark.django_db
+def test_set_order_by_orders_except_catchall_element():
+    # Except-catchall elements are built on a separate code path from
+    # datasource ones, and are just as much part of a report's output.
+    mtf = ContentType.objects.get_for_model(MyTestFoo)
+    for value in (3, 5, 4):
+        baker.make(MyTestFoo, i=value)
+
+    r = baker.make(Report, title="Report title")
+    t = baker.make(Table, label="table", base_model=mtf)
+    baker.make(Column, label="Value", parent=t, attr_name="i", position=0)
+
+    ds = baker.make(Datasource, base_model=mtf, dsl_query="i < 3")
+    baker.make(
+        ReportElement,
+        slug="caught",
+        table=t,
+        parent=r,
+        datasource=ds,
+        data_from=DATA_FROM_DATASOURCE,
+    )
+    rest = baker.make(
+        ReportElement,
+        slug="rest",
+        table=t,
+        parent=r,
+        datasource=None,
+        base_model=mtf,
+        data_from=DATA_FROM_EXCEPT_CATCHALL,
+    )
+
+    r.set_base_queryset(MyTestFoo.objects.all())
+    r.set_order_by("i")
+
+    res = django_tables2._report(r, {"request": None})
+
+    assert [o.i for o in res["elements"][rest.slug]["object_list"]] == [3, 4, 5]
+
+
+@pytest.mark.django_db
+def test_set_order_by_with_no_fields_falls_back_to_column_order(rf):
+    # Guard for the documented escape hatch: clearing the override must restore
+    # the table's stored ordering rather than leave the rows unsorted.
+    r, t, columns = _build_report(["Value"], values=(3, 1, 2))
+    baker.make(ColumnOrder, table=t, column=columns[0], desc=True, position=0)
+
+    r.set_order_by("i")
+    assert _rendered_cells(r, rf) == ["1", "2", "3"]
+
+    r.set_order_by()
+    assert _rendered_cells(r, rf) == ["3", "2", "1"]


### PR DESCRIPTION
## Problem

Kolejność wierszy raportu jest dziś **własnością tabeli**: inline `ColumnOrder`, czytany w adapterze django-tables2 i wstawiany do `Meta.order_by`. To znaczy, że sortowanie jest stałą zapisaną w bazie — dwa raporty chcące dwóch porządków wymagają dwóch tabel.

Gorzej: `Meta.order_by` operuje na **labelach kolumn**, a `Table.order_by` waliduje każdy alias względem zestawu kolumn tabeli. Nie da się więc posortować po polu, którego żadna kolumna nie pokazuje — a `Column` nie ma flagi „ukryta", więc jedynym obejściem byłoby wyświetlenie kolumny wyłącznie po to, żeby móc po niej sortować.

## Rozwiązanie

`Report.set_order_by(*fields)` — trzeci setter czasu renderu, obok istniejących `set_base_queryset()` i `set_context()`. Przyjmuje **nazwy pól ORM** (jak `QuerySet.order_by()`), nie labele kolumn, i wygrywa z `ColumnOrder` na czas jednego renderu.

Motywacja: widok, który daje użytkownikowi wybór sortowania — w tym sortowanie po wartości, którą raport pokazuje tylko jako część wyrenderowanego szablonu komórki.

## Dlaczego sortowanie querysetu, a nie `Meta.order_by`

Bo `Meta.order_by` wymagałby istnienia kolumny z odpowiednim akcesorem (patrz wyżej). Sortowanie querysetu to omija — ale wtedy własne sortowanie tabeli trzeba **usunąć**, nie tylko zignorować: django-tables2 stosuje `Meta.order_by` bezwarunkowo i przesortowałoby wiersze z powrotem. Przy pustej kolejności zostawia queryset w spokoju (`if accessors:` w jego `data.py`), więc porządek wołającego przeżywa.

## Zakres

Obie odmiany elementów raportu: `DATA_FROM_DATASOURCE` i `DATA_FROM_EXCEPT_CATCHALL`. Dla datasource'ów `order_by` nakładany jest **po** przekazaniu querysetu do księgowości `catchall` — te kopie są dalej OR-owane, a `ORDER BY` na operandach tylko by to zaciemnił.

## Kompatybilność wstecz

Bez wywołania `set_order_by()` zachowanie jest bit w bit takie jak dotąd — `ColumnOrder` nadal rządzi. Istniejące instalacje nie wymagają migracji danych ani żadnej akcji. Wywołanie settera bez argumentów przywraca fallback.

## Testy

Trzy nowe testy w `test_app/tests/test_adapters.py`, pisane TDD (każdy oglądany na czerwono przed implementacją):

- `test_set_order_by_overrides_column_order` — hook wygrywa z `ColumnOrder`; asercja przed wywołaniem hooka pilnuje przy okazji, że `ColumnOrder` nadal działa
- `test_set_order_by_orders_except_catchall_element` — druga gałąź kodu
- `test_set_order_by_with_no_fields_falls_back_to_column_order` — udokumentowana furtka

Cała suita: **86 passed, 1 skipped**. `ruff check` / `ruff format` / `pre-commit` czysto.

## Dokumentacja

`docs/concepts.md` i `docs/rendering.md` (sekcja „From a view") — setter opisany obok dwóch pozostałych, z jawnym ostrzeżeniem o różnicy „nazwy pól ORM vs labele kolumn". Wpis w `HISTORY.md` pod `## (unreleased)`.

## Uwaga o wydaniu

Konsumentem jest BPP (osobny PR, sortowanie raportów po nazwiskach autorów), który potrzebuje wydanej wersji — po zmergowaniu tego trzeba `release:` i bump w `pyproject.toml` BPP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSUsgzYoDNnXpXGAn5otJg